### PR TITLE
Package maintenance and pytest workflow

### DIFF
--- a/.github/workflows/hari-client-pytest.yaml
+++ b/.github/workflows/hari-client-pytest.yaml
@@ -27,5 +27,16 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .[tests]
 
+      - name: Get changed files
+        id: changes
+        run: echo "files=$(git diff --name-only origin/master...${{ github.event.pull_request.head.sha }} | xargs)" >> $GITHUB_OUTPUT
+
+      - name: Run pre-commit on changed files
+        run: |
+          changed_files="${{ steps.changes.outputs.files }}"
+          if [ -n "$changed_files" ]; then
+            pre-commit run --files $changed_files || exit 1
+          fi
+
       - name: Run tests with pytest
         run: pytest

--- a/.github/workflows/hari-client-pytest.yaml
+++ b/.github/workflows/hari-client-pytest.yaml
@@ -1,0 +1,34 @@
+name: Hari-Client PyTest
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.11, 3.12]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[tests]
+
+      - name: Run tests with pytest
+        run: pytest

--- a/.github/workflows/hari-client-pytest.yaml
+++ b/.github/workflows/hari-client-pytest.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get changed files
         id: changes
-        run: echo "files=$(git diff --name-only origin/master...${{ github.event.pull_request.head.sha }} | xargs)" >> $GITHUB_OUTPUT
+        run: echo "files=$(git diff --name-only origin/main...${{ github.event.pull_request.head.sha }} | xargs)" >> $GITHUB_OUTPUT
 
       - name: Run pre-commit on changed files
         run: |

--- a/.github/workflows/hari-client-pytest.yaml
+++ b/.github/workflows/hari-client-pytest.yaml
@@ -1,9 +1,6 @@
 name: Hari-Client PyTest
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/hari-client-pytest.yaml
+++ b/.github/workflows/hari-client-pytest.yaml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          # Required for git diff
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/hari-client-pytest.yaml
+++ b/.github/workflows/hari-client-pytest.yaml
@@ -16,9 +16,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-        with:
-          # Required for git diff
-          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -29,17 +26,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[tests]
-
-      - name: Get changed files
-        id: changes
-        run: echo "files=$(git diff --name-only origin/main...${{ github.event.pull_request.head.sha }} | xargs)" >> $GITHUB_OUTPUT
-
-      - name: Run pre-commit on changed files
-        run: |
-          changed_files="${{ steps.changes.outputs.files }}"
-          if [ -n "$changed_files" ]; then
-            pre-commit run --files $changed_files || exit 1
-          fi
 
       - name: Run tests with pytest
         run: pytest

--- a/.github/workflows/pre-commit-test.yaml
+++ b/.github/workflows/pre-commit-test.yaml
@@ -1,0 +1,38 @@
+name: Pre-Commit Hook Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          # Required for git diff
+          fetch-depth: 0
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install Pre-Commit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pre-commit
+
+      - name: Get changed files
+        id: changes
+        run: echo "files=$(git diff --name-only origin/main...${{ github.event.pull_request.head.sha }} | xargs)" >> $GITHUB_OUTPUT
+
+      - name: Run pre-commit on changed files
+        run: |
+          changed_files="${{ steps.changes.outputs.files }}"
+          if [ -n "$changed_files" ]; then
+            pre-commit run --files $changed_files || exit 1
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.9
+  python: python3.11
 default_stages: [commit, push, prepare-commit-msg]
 repos:
   ############################################

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ## TBD - TBD
 
-### Updated
+### New Features
 
 - added response types for metadate creation endpoints
 - updated generic parser to work with list of parametrized generics
+
+### Breaking Changes
+
+- update minimum python version to be 3.11
+
+## [0.1.0] - 2024-07-25
+
+Initial Release of hari-client with version 0.1.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-Minimum python version: 3.9
+Minimum python version: **3.11**
 
 To install the hari-client package, use pip with the following command:
 
@@ -91,6 +91,10 @@ Have a look at the [geometries.py](docs/example_code/geometries.py) example scri
 ## Documentation
 
 For more detailed documentation, including all available methods and their parameters, please refer to the official documentation https://docs.quality-match.com.
+
+## Changelog
+
+See: [CHANGELOG.md](CHANGELOG.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ For more detailed documentation, including all available methods and their param
 
 See: [CHANGELOG.md](CHANGELOG.md)
 
+## Development Setup
+
+To set up your local development environment, follow these steps:
+
+- Clone the repository
+- Setup a virtual environment with Python 3.11
+- Install the package in editable mode with the following command:
+  ```bash
+  python -m pip install -e .[tests]
+  ```
+  - This also installs pytest and the [pre-commit](https://github.com/pre-commit/pre-commit) tool into the environment
+- Install the pre-commit hooks with the following command:
+  ```bash
+  pre-commit install
+  ```
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for more details.
@@ -103,3 +119,7 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 ## Contact
 
 Visit our website https://quality-match.com
+
+```
+
+```

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,9 @@ setup(
     author_email="info@quality-match.com",
     packages=find_packages(),
     install_requires=["requests>=2.32", "pydantic>=2.8", "pydantic-settings>=2.3"],
-    extras_require={"tests": ["pytest"]},
+    extras_require={"tests": ["pytest", "pre-commit"]},
     classifiers=[
         "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
     ],


### PR DESCRIPTION
- Changed minimum python version to 3.11, due to the features used in https://github.com/quality-match/hari-client/pull/1
- Added github actions workflow for running pytest tests when creating a PR towards `main`
- Link Changelog in Readme
- Explain development setup in Readme