### PR TITLE
Fix pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,9 +48,8 @@ repos:
     rev: 7.1.0
     hooks:
       - id: flake8
-        files: templates/
-        # ignore line-length-PEP
-        args: [--ignore=E501]
+        # ignore some PEPs conflicting with black
+        args: [--max-line-length=88,--extend-ignore=E203 E501,]
 
   # Autoflake for removing unused imports
   -   repo: https://github.com/PyCQA/autoflake

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,8 +39,7 @@ repos:
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
-        files: templates/fast_api_application
-
+        additional_dependencies: [types-requests]
   ############################################
   #  Flake8 - style guide checker
   ############################################

--- a/docs/example_code/quickstart.py
+++ b/docs/example_code/quickstart.py
@@ -122,8 +122,9 @@ hari.trigger_histograms_update_job(
 
 # in order to trigger crops creation, thumbnails should be created first.
 # give the thumbnails creation job time to start
-thumbnails_job_id = ""
-while thumbnails_job_id == "":
+uuid_nil = uuid.UUID("00000000-0000-0000-0000-000000000000")
+thumbnails_job_id = uuid_nil
+while thumbnails_job_id == uuid_nil:
     # query all the jobs for the given trace_id
     jobs = hari.get_processing_jobs(trace_id=trace_id)
     # try to get the thumbnails creation job id
@@ -134,10 +135,10 @@ while thumbnails_job_id == "":
             if job.process_name
             == models.ProcessingJobsForMetadataUpdate.THUMBNAILS_CREATION
         ),
-        "",
+        uuid_nil,
     )
 
-    if thumbnails_job_id != "":
+    if thumbnails_job_id != uuid_nil:
         break
     time.sleep(5)
 

--- a/hari_client/__init__.py
+++ b/hari_client/__init__.py
@@ -4,4 +4,4 @@ from hari_client.config.config import Config
 from hari_client.models import models
 from hari_client.upload import hari_uploader
 
-__all__ = [HARIClient, Config, errors, models, hari_uploader]
+__all__ = ["HARIClient", "Config", "errors", "models", "hari_uploader"]

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -99,7 +99,7 @@ def _parse_response_model(
             response_data=response_data,
             response_model=response_model,
             message=f"Can't parse response_data into response_model {response_model},"
-            + f" because the combination of received data and expected response_model is unhandled."
+            + " because the combination of received data and expected response_model is unhandled."
             + f"{response_data=}.",
         )
     except Exception as err:
@@ -164,7 +164,7 @@ class HARIClient:
         if not response.ok:
             raise errors.APIError(response)
 
-        if not "application/json" in response.headers.get("Content-Type", ""):
+        if "application/json" not in response.headers.get("Content-Type", ""):
             raise ValueError(
                 "Expected application/json to be in Content-Type header, but couldn't find it."
             )
@@ -315,7 +315,8 @@ class HARIClient:
 
         return presign_response
 
-    ### dataset ###
+    """DATASET"""
+
     def create_dataset(
         self,
         name: str,
@@ -371,7 +372,7 @@ class HARIClient:
         """
         return self._request(
             "POST",
-            f"/datasets",
+            "/datasets",
             json=self._pack(locals(), not_none=["creation_timestamp", "id"]),
             success_response_item_model=models.Dataset,
         )
@@ -465,7 +466,7 @@ class HARIClient:
         """
         return self._request(
             "GET",
-            f"/datasets",
+            "/datasets",
             params=self._pack(locals()),
             success_response_item_model=list[models.DatasetResponse],
         )
@@ -512,7 +513,8 @@ class HARIClient:
             "DELETE", f"/datasets/{dataset_id}", success_response_item_model=str
         )
 
-    ### subset ###
+    """SUBSET"""
+
     def create_subset(
         self,
         dataset_id: str,
@@ -538,12 +540,13 @@ class HARIClient:
         """
         return self._request(
             "POST",
-            f"/subsets:createFiltered",
+            "/subsets:createFiltered",
             params=self._pack(locals()),
             success_response_item_model=str,
         )
 
-    ### media ###
+    """MEDIA"""
+
     def create_media(
         self,
         dataset_id: str,
@@ -1047,7 +1050,8 @@ class HARIClient:
             success_response_item_model=list[models.MediaUploadUrlInfo],
         )
 
-    ### media object ###
+    """MEDIA OBJECT"""
+
     def create_media_object(
         self,
         dataset_id: str,
@@ -1375,7 +1379,8 @@ class HARIClient:
             success_response_item_model=models.Visualisation,
         )
 
-    ### metadata ###
+    """METADATA"""
+
     def trigger_thumbnails_creation_job(
         self,
         dataset_id: str,
@@ -1489,7 +1494,8 @@ class HARIClient:
             ],
         )
 
-    ### processing_jobs ###
+    """PROCESSING JOBS"""
+
     def get_processing_jobs(
         self,
         trace_id: str = None,

--- a/hari_client/client/errors.py
+++ b/hari_client/client/errors.py
@@ -13,7 +13,7 @@ class APIError(Exception):
         message = ""
         try:
             message = response.json()
-        except:
+        except Exception:
             pass
         super().__init__(f"{http_response_status_code=}: {message=}")
 

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -853,7 +853,7 @@ class ResponseStatesEnum(str, enum.Enum):
     BAD_DATA = "bad_data"
 
 
-class BaseBulkItemResponse(pydantic.BaseModel, arbitrary_types_allowed=True):
+class BaseBulkItemResponse(pydantic.BaseModel):
     item_id: typing.Optional[str] = None
     status: ResponseStatesEnum
     errors: typing.Optional[list[str]] = None

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,10 @@ setup(
         "pydantic-settings>=2.3",
         "tqdm~=4.66",
     ],
-    extras_require={"tests": ["pytest", "pytest-mock", "pre-commit"]},
+    extras_require={
+        "tests": ["pytest", "pytest-mock"],
+        "dev": ["pre-commit", "types-requests"],
+    },
     classifiers=[
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
# Changes
## Pre-commit hooks
Use mypy and flake8 for pre-commit hooks.

I had to invalidate mypy a bit because the [parse_response_model-method](https://github.com/quality-match/hari-client/blob/81a31c89b43d3251a3b89499e2ccc0cd9ff3a40d/hari_client/client/client.py#L19-L21) has too many return types, which have to be propagated throughout almost every method in the client.

I stopped after a while because there was no end in sight to make this conform with the type checker.
We should look at the return types of the parse_response_model-method and figure out a way to make this mypy-conform to give us type-safety.

## Setup
Added another extra requires for developers in setup.py