### PR TITLE
Use proper pydantic models for response parsing

### DIFF
--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -24,15 +24,8 @@ def _parse_response_model(
         - both response_data and response_model are None (meaning you expect to receive None as response)
             - None is returned
         - response_model is a pydantic model:
-            - if response_data is a dict, response_data is parsed into an instance of the response_model.
-            - if response_data is a list, each item in the list is treated as a dict and parsed into an instance of the response_model.
-        - response_model is a parametrized generic:
-            - if response_data is a list and response_model is a list of unions:
-                - each item in the response_data list is checked against the possible types in the union.
-                - the parser attempts to parse each item using each type in the union until one succeeds.
-                - if an item is successfully parsed into one of the union types, and it contains nested fields that are also complex structures (e.g., lists of unions), the parser recurses into those nested structures to fully parse them.
-            - if response_data is a dict and response_model is a dict with specified key and value types:
-                - each key-value pair in the response_data dict is parsed, with the keys being converted to the specified key type, and the values being recursively parsed according to the specified value type.
+            - if response_data is a dict or list, response_data is parsed into an instance of the response_model.
+            - raises error otherwise
         - response_data is of the expected type (response_model):
             - The response_data is returned as is.
 
@@ -44,86 +37,52 @@ def _parse_response_model(
         errors.ParseResponseModelError: When parsing fails for any reason
 
     Returns:
-        T: The passed response_model type
+        T: an instance of the passed response_model type
     """
-    # The response_data can have many different types:
-    # --> custom classes, dict, list, primitives (str, int, etc.), None
     try:
-        if response_model is None:
-            if response_data is None:
+        if response_model is None or response_data is None:
+            if response_model is None and response_data is None:
                 return None
             raise errors.ParseResponseModelError(
                 response_data=response_data,
                 response_model=response_model,
-                message=f"Expected response_data to be None, but received {response_data=}",
+                message=f"Failed to parse response_data into response_model {response_model}. {response_data=}. Types do not match.",
             )
-
         # handle pydantic models
+        # order is important here, because the RootModel is a subclass of the BaseModel
         if isinstance(response_model, type) and issubclass(
+            response_model, pydantic.RootModel
+        ):
+            root_field_type = typing.get_origin(
+                response_model.model_fields["root"].annotation
+            )
+            if issubclass(root_field_type, list):
+                return response_model(response_data)
+            else:
+                raise errors.ParseResponseModelError(
+                    response_data=response_data,
+                    response_model=response_model,
+                    message=f"Failed to parse response_data into response_model {response_model}. {response_data=}, because the root field type of the response_data is '{root_field_type}', which is not supported.",
+                )
+        elif isinstance(response_model, type) and issubclass(
             response_model, pydantic.BaseModel
         ):
-            if isinstance(response_data, dict):
-                return response_model(**response_data)
-            elif isinstance(response_data, list):
-                return [response_model(**item) for item in response_data]
-
-        # handle parametrized generics
-        origin = typing.get_origin(response_model)
-        if origin is list:
-            item_type = typing.get_args(response_model)[0]
-            if isinstance(response_data, list):
-                if typing.get_origin(item_type) is typing.Union:
-                    return [
-                        handle_union_parsing(item, item_type) for item in response_data
-                    ]
-                elif isinstance(item_type, type) and issubclass(
-                    item_type, pydantic.BaseModel
-                ):
-                    return [item_type(**item) for item in response_data]
-                else:
-                    return [item_type(item) for item in response_data]
-        if origin is dict:
-            key_type, value_type = typing.get_args(response_model)
-            if isinstance(response_data, dict):
-                return {
-                    key_type(k): (
-                        value_type(**v) if isinstance(v, dict) else value_type(v)
-                    )
-                    for k, v in response_data.items()
-                }
+            return response_model(**response_data)
 
         if isinstance(response_data, response_model):
             return response_data
-
-        raise errors.ParseResponseModelError(
-            response_data=response_data,
-            response_model=response_model,
-            message=f"Can't parse response_data into response_model {response_model},"
-            + f" because the combination of received data and expected response_model is unhandled."
-            + f"{response_data=}.",
-        )
-    except Exception as err:
+        else:
+            raise errors.ParseResponseModelError(
+                response_data=response_data,
+                response_model=response_model,
+                message=f"Failed to parse response_data into response_model {response_model}. {response_data=}. Types do not match.",
+            )
+    except pydantic.ValidationError as err:
         raise errors.ParseResponseModelError(
             response_data=response_data,
             response_model=response_model,
             message=f"Failed to parse response_data into response_model {response_model}. {response_data=}",
         ) from err
-
-
-def handle_union_parsing(item, union_type):
-    for possible_type in typing.get_args(union_type):
-        if isinstance(possible_type, type) and issubclass(
-            possible_type, pydantic.BaseModel
-        ):
-            try:
-                return possible_type(**item)
-            except Exception:
-                continue
-    raise errors.ParseResponseModelError(
-        response_data=item,
-        response_model=union_type,
-        message=f"Failed to parse item into one of the union types {union_type}. {item=}",
-    )
 
 
 class HARIClient:
@@ -143,7 +102,7 @@ class HARIClient:
         url: str,
         success_response_item_model: typing.Type[T],
         **kwargs,
-    ) -> typing.Union[T, None]:
+    ) -> T:
         """Make a request to the API.
 
         Args:
@@ -164,7 +123,7 @@ class HARIClient:
         if not response.ok:
             raise errors.APIError(response)
 
-        if not "application/json" in response.headers.get("Content-Type", ""):
+        if "application/json" not in response.headers.get("Content-Type", ""):
             raise ValueError(
                 "Expected application/json to be in Content-Type header, but couldn't find it."
             )
@@ -315,11 +274,12 @@ class HARIClient:
 
         return presign_response
 
-    ### dataset ###
+    """DATASET"""
+
     def create_dataset(
         self,
         name: str,
-        mediatype: typing.Optional[models.MediaType] = "image",
+        mediatype: typing.Optional[models.MediaType] = models.MediaType.IMAGE,
         customer: typing.Optional[str] = None,
         creation_timestamp: typing.Optional[str] = None,
         reference_files: typing.Optional[list] = None,
@@ -371,7 +331,7 @@ class HARIClient:
         """
         return self._request(
             "POST",
-            f"/datasets",
+            "/datasets",
             json=self._pack(locals(), not_none=["creation_timestamp", "id"]),
             success_response_item_model=models.Dataset,
         )
@@ -450,7 +410,7 @@ class HARIClient:
         visibility_statuses: typing.Optional[tuple] = (
             models.VisibilityStatus.VISIBLE,
         ),
-    ) -> list[models.DatasetResponse]:
+    ) -> models.DatasetResponseList:
         """Returns all datasets that a user has access to.
 
         Args:
@@ -458,16 +418,16 @@ class HARIClient:
             visibility_statuses: Visibility statuses of the returned datasets
 
         Returns:
-            A list of datasets
+            A pydantic object with a list of datasets
 
         Raises:
             APIException: If the request fails.
         """
         return self._request(
             "GET",
-            f"/datasets",
+            "/datasets",
             params=self._pack(locals()),
-            success_response_item_model=list[models.DatasetResponse],
+            success_response_item_model=models.DatasetResponseList,
         )
 
     def get_subsets_for_dataset(
@@ -512,7 +472,8 @@ class HARIClient:
             "DELETE", f"/datasets/{dataset_id}", success_response_item_model=str
         )
 
-    ### subset ###
+    """SUBSET"""
+
     def create_subset(
         self,
         dataset_id: str,
@@ -538,12 +499,13 @@ class HARIClient:
         """
         return self._request(
             "POST",
-            f"/subsets:createFiltered",
+            "/subsets:createFiltered",
             params=self._pack(locals()),
             success_response_item_model=str,
         )
 
-    ### media ###
+    """MEDIA"""
+
     def create_media(
         self,
         dataset_id: str,
@@ -799,7 +761,7 @@ class HARIClient:
         file_extension: str,
         visualisation_config_id: str,
         batch_size: int,
-    ) -> list[models.VisualisationUploadUrlInfo]:
+    ) -> models.VisualisationUploadUrlInfoList:
         """
         Creates a presigned upload URL for a file to be uploaded to S3 and used for visualisations.
 
@@ -810,7 +772,7 @@ class HARIClient:
             batch_size (int): number of upload links and ids to generate. Valid range: 1 <= batch_size <= 500.
 
         Returns:
-            list[models.VisualisationUploadUrlInfo]: A list with UploadUrlInfo objects containing the presigned
+            models.VisualisationUploadUrlInfoList: A pydantic object with a list of UploadUrlInfo objects containing the presigned
                 upload URL and the media_url which should be used when creating the media.
 
         Raises:
@@ -828,12 +790,12 @@ class HARIClient:
             "GET",
             f"/datasets/{dataset_id}/visualisations/uploadUrl",
             params=self._pack(locals(), ignore=["dataset_id"]),
-            success_response_item_model=list[models.VisualisationUploadUrlInfo],
+            success_response_item_model=models.VisualisationUploadUrlInfoList,
         )
 
     def get_media_histograms(
         self, dataset_id: str, subset_id: typing.Optional[str] = None
-    ) -> list[models.AttributeHistogram]:
+    ) -> models.AttributeHistogramList:
         """Get the histogram data
 
         Args:
@@ -841,7 +803,7 @@ class HARIClient:
             subset_id: The subset Id
 
         Returns:
-            A list of media histograms
+            A pydantic object with a list of media histograms
 
         Raises:
             APIException: If the request fails.
@@ -850,12 +812,12 @@ class HARIClient:
             "GET",
             f"/datasets/{dataset_id}/medias/histograms",
             params=self._pack(locals(), ignore=["dataset_id"]),
-            success_response_item_model=list[models.AttributeHistogram],
+            success_response_item_model=models.AttributeHistogramList,
         )
 
     def get_instance_histograms(
         self, dataset_id: str, subset_id: typing.Optional[str] = None
-    ) -> list[models.AttributeHistogram]:
+    ) -> models.AttributeHistogramList:
         """Get the histogram data
 
         Args:
@@ -863,7 +825,7 @@ class HARIClient:
             subset_id: Subset Id
 
         Returns:
-            list
+            A pydantic object with a list of instance histograms
 
         Raises:
             APIException: If the request fails.
@@ -872,7 +834,7 @@ class HARIClient:
             "GET",
             f"/datasets/{dataset_id}/instances/histograms",
             params=self._pack(locals(), ignore=["dataset_id"]),
-            success_response_item_model=list[models.AttributeHistogram],
+            success_response_item_model=models.AttributeHistogramList,
         )
 
     def get_media_object_count_statistics(
@@ -1016,7 +978,7 @@ class HARIClient:
 
     def get_presigned_media_upload_url(
         self, dataset_id: str, file_extension: str, batch_size: int
-    ) -> list[models.MediaUploadUrlInfo]:
+    ) -> models.MediaUploadUrlInfoList:
         """
         Creates a presigned upload URL for a file to be uploaded to S3 and used for medias.
 
@@ -1026,7 +988,7 @@ class HARIClient:
             batch_size (int): number of upload links and ids to generate. Valid range: 1 <= batch_size <= 500.
 
         Returns:
-            list[models.MediaUploadUrlInfo]: A list with MediaUploadUrlInfo objects containing the presigned
+            models.MediaUploadUrlInfoList: A pydantic object with a list of MediaUploadUrlInfo objects containing the presigned
                 upload URL and the media_url which should be used when creating the media.
 
         Raises:
@@ -1044,10 +1006,11 @@ class HARIClient:
             "GET",
             f"/datasets/{dataset_id}/medias/uploadUrl",
             params=self._pack(locals(), ignore=["dataset_id"]),
-            success_response_item_model=list[models.MediaUploadUrlInfo],
+            success_response_item_model=models.MediaUploadUrlInfoList,
         )
 
-    ### media object ###
+    """MEDIA OBJECT"""
+
     def create_media_object(
         self,
         dataset_id: str,
@@ -1231,7 +1194,7 @@ class HARIClient:
         skip: typing.Optional[int] = None,
         query: typing.Optional[models.QueryList] = None,
         sort: typing.Optional[list[models.SortingParameter]] = None,
-    ) -> list[models.MediaObjectResponse]:
+    ) -> models.MediaObjectResponseList:
         """Queries the database based on the submitted parameters and returns a
 
         Args:
@@ -1244,7 +1207,7 @@ class HARIClient:
             sort: Sort
 
         Returns:
-            list
+            models.MediaObjectResponseList: A pydantic object with a list of media object responses
 
         Raises:
             APIException: If the request fails.
@@ -1253,7 +1216,7 @@ class HARIClient:
             "GET",
             f"/datasets/{dataset_id}/mediaObjects",
             params=self._pack(locals(), ignore=["dataset_id"]),
-            success_response_item_model=list[models.MediaObjectResponse],
+            success_response_item_model=models.MediaObjectResponseList,
         )
 
     def archive_media_object(self, dataset_id: str, media_object_id: str) -> str:
@@ -1277,7 +1240,7 @@ class HARIClient:
 
     def get_media_object_histograms(
         self, dataset_id: str, subset_id: typing.Optional[str] = None
-    ) -> list[models.AttributeHistogram]:
+    ) -> models.AttributeHistogramList:
         """Get the histogram data
 
         Args:
@@ -1285,7 +1248,7 @@ class HARIClient:
             subset_id: Subset Id
 
         Returns:
-            Histograms of the media object
+            A pydantic object with a list of media object histograms
 
         Raises:
             APIException: If the request fails.
@@ -1294,7 +1257,7 @@ class HARIClient:
             "GET",
             f"/datasets/{dataset_id}/mediaObjects/histograms",
             params=self._pack(locals(), ignore=["dataset_id"]),
-            success_response_item_model=list[models.AttributeHistogram],
+            success_response_item_model=models.AttributeHistogramList,
         )
 
     def get_media_object_count(
@@ -1375,7 +1338,8 @@ class HARIClient:
             success_response_item_model=models.Visualisation,
         )
 
-    ### metadata ###
+    """METADATA"""
+
     def trigger_thumbnails_creation_job(
         self,
         dataset_id: str,
@@ -1383,7 +1347,7 @@ class HARIClient:
         trace_id: typing.Optional[str] = None,
         max_size: typing.Optional[tuple[int]] = None,
         aspect_ratio: typing.Optional[tuple[int]] = None,
-    ) -> list[models.CreateThumbnailsResponse]:
+    ) -> models.CreateThumbnailsResponseList:
         """Triggers the creation of thumbnails for a given dataset.
 
         Args:
@@ -1397,7 +1361,7 @@ class HARIClient:
             APIException: If the request fails.
 
         Returns:
-            list[models.CreateThumbnailsResponse]: list of the created thumbnails
+            models.CreateThumbnailsResponseList: A pydantic object with a list of the created thumbnails
         """
         params = {"subset_id": subset_id}
 
@@ -1409,7 +1373,7 @@ class HARIClient:
             f"/datasets/{dataset_id}/thumbnails",
             params=params,
             json=self._pack(locals(), ignore=["dataset_id", "subset_id", "trace_id"]),
-            success_response_item_model=list[models.CreateThumbnailsResponse],
+            success_response_item_model=models.CreateThumbnailsResponseList,
         )
 
     def trigger_histograms_update_job(
@@ -1431,7 +1395,9 @@ class HARIClient:
         Returns:
             models.UpdateHistogramsResponse: updated histograms
         """
-        params = {"compute_for_all_subsets": compute_for_all_subsets}
+        params: dict[str, bool | str] = {
+            "compute_for_all_subsets": compute_for_all_subsets
+        }
 
         if trace_id is not None:
             params["trace_id"] = trace_id
@@ -1452,9 +1418,7 @@ class HARIClient:
         max_size: typing.Optional[tuple[int]] = None,
         padding_minimum: typing.Optional[int] = None,
         padding_percent: typing.Optional[int] = None,
-    ) -> list[
-        typing.Union[models.UpdateHistogramsResponse, models.CreateCropsResponse],
-    ]:
+    ) -> models.MetadataResponseList:
         """Creates the crops for a given dataset if the correct api key is provided in the
 
         Args:
@@ -1470,7 +1434,7 @@ class HARIClient:
             APIException: If the request fails.
 
         Returns:
-            list[typing.Union[models.UpdateHistogramsResponse, models.CreateCropsResponse]]: list of updated histograms and created crops
+            models.MetadataResponseList: A pydantic object with a list of updated histograms and created crops
         """
         params = {"subset_id": subset_id}
 
@@ -1482,18 +1446,15 @@ class HARIClient:
             f"/datasets/{dataset_id}/crops",
             params=params,
             json=self._pack(locals(), ignore=["dataset_id", "subset_id", "trace_id"]),
-            success_response_item_model=list[
-                typing.Union[
-                    models.UpdateHistogramsResponse, models.CreateCropsResponse
-                ],
-            ],
+            success_response_item_model=models.MetadataResponseList,
         )
 
-    ### processing_jobs ###
+    """PROCESSING JOBS"""
+
     def get_processing_jobs(
         self,
         trace_id: str = None,
-    ) -> list[models.ProcessingJob]:
+    ) -> models.ProcessingJobList:
         """
         Retrieves the list of processing jobs that the user has access to.
 
@@ -1504,7 +1465,7 @@ class HARIClient:
             APIException: If the request fails.
 
         Returns:
-            list[models.ProcessingJob]: A list of processing jobs for the user
+            models.ProcessingJobList: A pydantic object with a list of processing jobs for the user
             or [] if there are no jobs of trace_id is not found.
         """
         params = {}
@@ -1515,7 +1476,7 @@ class HARIClient:
             "GET",
             "/processingJobs",
             params=params,
-            success_response_item_model=list[models.ProcessingJob],
+            success_response_item_model=models.ProcessingJobList,
         )
 
     def get_processing_job(

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -46,7 +46,7 @@ def _parse_response_model(
             raise errors.ParseResponseModelError(
                 response_data=response_data,
                 response_model=response_model,
-                message=f"Failed to parse response_data into response_model {response_model}. {response_data=}. Types do not match.",
+                message=f"Failed to parse response_data into response_model {response_model}. {response_data=}. Cannot parse None type into a non-None type.",
             )
         # handle pydantic models
         # order is important here, because the RootModel is a subclass of the BaseModel
@@ -74,14 +74,14 @@ def _parse_response_model(
         else:
             raise errors.ParseResponseModelError(
                 response_data=response_data,
+                message=f"Failed to parse response_data into response_model {response_model}. {response_data=}. The response_data or the response model are not of the expected type.",
                 response_model=response_model,
-                message=f"Failed to parse response_data into response_model {response_model}. {response_data=}. Types do not match.",
             )
     except pydantic.ValidationError as err:
         raise errors.ParseResponseModelError(
             response_data=response_data,
             response_model=response_model,
-            message=f"Failed to parse response_data into response_model {response_model}. {response_data=}",
+            message=f"Failed to parse response_data into response_model {response_model}. {response_data=}.",
         ) from err
 
 

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -1385,7 +1385,7 @@ class HARIClient:
         dataset_id: str,
         trace_id: typing.Optional[str] = None,
         compute_for_all_subsets: typing.Optional[bool] = False,
-    ) -> models.UpdateHistogramsResponse:
+    ) -> models.UpdateHistogramsResponseList:
         """Triggers the update of the histograms for a given dataset.
 
         Args:
@@ -1410,7 +1410,7 @@ class HARIClient:
             "PUT",
             f"/datasets/{dataset_id}/histograms",
             params=params,
-            success_response_item_model=models.UpdateHistogramsResponse,
+            success_response_item_model=models.UpdateHistogramsResponseList,
         )
 
     def trigger_crops_creation_job(

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -479,6 +479,8 @@ class HARIClient:
         dataset_id: str,
         subset_type: models.SubsetType,
         subset_name: str,
+        filter_options: models.QueryList | None = None,
+        secondary_filter_options: models.QueryList | None = None,
         object_category: typing.Optional[bool] = False,
         visualisation_config_id: typing.Optional[str] = None,
     ) -> str:
@@ -488,6 +490,8 @@ class HARIClient:
             dataset_id: Dataset Id
             subset_type: Type of the subset (media, media_object, instance, attribute)
             subset_name: The name of the subset
+            filter_options: Filter options defining subset
+            secondary_filter_options: In Media subsets these will filter down the media_objects
             object_category: True if the new subset shall be shown as a category for objects in HARI
             visualisation_config_id: Visualisation Config Id
 

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -40,9 +40,9 @@ def _parse_response_model(
         T: an instance of the passed response_model type
     """
     try:
-        if response_model is None or response_data is None:
-            if response_model is None and response_data is None:
-                return None
+        if response_model is None and response_data is None:
+            return None
+        elif response_model is None or response_data is None:
             raise errors.ParseResponseModelError(
                 response_data=response_data,
                 response_model=response_model,

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -46,7 +46,7 @@ def _parse_response_model(
             raise errors.ParseResponseModelError(
                 response_data=response_data,
                 response_model=response_model,
-                message=f"Failed to parse response_data into response_model {response_model}. {response_data=}. Cannot parse None type into a non-None type.",
+                message=f"Failed to parse response_data into response_model {response_model}. {response_data=}. Cannot parse None type into a non-None type and vice versa.",
             )
         # handle pydantic models
         # order is important here, because the RootModel is a subclass of the BaseModel

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -1064,6 +1064,14 @@ class UpdateHistogramsResponse(ResponseBaseParameters):
     parameters: UpdateHistogramsParameters = pydantic.Field(title="Parameters")
 
 
+class UpdateHistogramsResponseList(pydantic.RootModel[list[UpdateHistogramsResponse]]):
+    def __iter__(self):
+        return iter(self.root)
+
+    def __getitem__(self, item):
+        return self.root[item]
+
+
 class CreateCropsParameters(pydantic.BaseModel):
     dataset_id: str = pydantic.Field(title="Dataset ID")
     query: typing.Optional[QueryList] = pydantic.Field(default=None, title="Query")

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -8,6 +8,10 @@ import uuid
 import pydantic
 
 
+class BaseResponse(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="allow")
+
+
 class VideoParameters(str, enum.Enum):
     # Currently empty
     pass
@@ -264,7 +268,7 @@ class Dataset(pydantic.BaseModel):
     )
 
 
-class DatasetResponse(pydantic.BaseModel):
+class DatasetResponse(BaseResponse):
     id: str = pydantic.Field(title="Id")
     name: str = pydantic.Field(title="Name")
     parent_dataset: typing.Optional[str] = pydantic.Field(
@@ -528,7 +532,7 @@ class Media(pydantic.BaseModel):
     )
 
 
-class MediaResponse(pydantic.BaseModel):
+class MediaResponse(BaseResponse):
     id: typing.Optional[str] = pydantic.Field(default=None, title="Id")
     dataset_id: typing.Optional[str] = pydantic.Field(default=None, title="Dataset Id")
     tags: typing.Optional[list] = pydantic.Field(default=None, title="Tags")
@@ -703,7 +707,7 @@ class MediaObject(pydantic.BaseModel):
     )
 
 
-class MediaObjectResponse(pydantic.BaseModel):
+class MediaObjectResponse(BaseResponse):
     id: typing.Optional[str] = pydantic.Field(default=None, title="Id")
     dataset_id: typing.Optional[str] = pydantic.Field(default=None, title="Dataset Id")
     tags: typing.Optional[list] = pydantic.Field(default=None, title="Tags")
@@ -853,7 +857,7 @@ class ResponseStatesEnum(str, enum.Enum):
     BAD_DATA = "bad_data"
 
 
-class BaseBulkItemResponse(pydantic.BaseModel, arbitrary_types_allowed=True):
+class BaseBulkItemResponse(BaseResponse):
     item_id: typing.Optional[str] = None
     status: ResponseStatesEnum
     errors: typing.Optional[list[str]] = None
@@ -867,7 +871,7 @@ class AttributeCreateResponse(BaseBulkItemResponse):
     annotatable_id: str
 
 
-class BulkResponse(pydantic.BaseModel):
+class BulkResponse(BaseResponse):
     status: BulkOperationStatusEnum = BulkOperationStatusEnum.PROCESSING
     summary: BulkUploadSuccessSummary = pydantic.Field(
         default_factory=BulkUploadSuccessSummary
@@ -933,7 +937,7 @@ class ProcessingJobsForMetadataUpdate(str, enum.Enum):
     CROPS_CREATION = "create_crops"
 
 
-class ResponseBaseParameters(pydantic.BaseModel):
+class ResponseBaseParameters(BaseResponse):
     batch: bool = pydantic.Field(default=False, title="Batch")
     override_processing_type: typing.Optional[ProcessingType] = pydantic.Field(
         default=None, title="Override Processing Type"

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -301,6 +301,14 @@ class DatasetResponse(BaseResponse):
     )
 
 
+class DatasetResponseList(pydantic.RootModel[list[DatasetResponse]]):
+    def __iter__(self):
+        return iter(self.root)
+
+    def __getitem__(self, item):
+        return self.root[item]
+
+
 class Pose3D(pydantic.BaseModel):
     position: Point3DTuple = pydantic.Field()
     heading: QuaternionTuple = pydantic.Field()
@@ -574,6 +582,14 @@ class MediaResponse(BaseResponse):
     )
 
 
+class MediaResponseList(pydantic.RootModel[list[MediaResponse]]):
+    def __iter__(self):
+        return iter(self.root)
+
+    def __getitem__(self, item):
+        return self.root[item]
+
+
 class FilterCount(pydantic.BaseModel):
     false_negative_percentage: typing.Optional[typing.Any] = pydantic.Field(
         default=None, title="False Negative Percentage"
@@ -753,6 +769,14 @@ class MediaObjectResponse(BaseResponse):
     )
 
 
+class MediaObjectResponseList(pydantic.RootModel[list[MediaObjectResponse]]):
+    def __iter__(self):
+        return iter(self.root)
+
+    def __getitem__(self, item):
+        return self.root[item]
+
+
 class ValidationError(pydantic.BaseModel):
     loc: list = pydantic.Field(title="Location")
     msg: str = pydantic.Field(title="Message")
@@ -802,16 +826,42 @@ class AttributeHistogram(pydantic.BaseModel):
     statistics: typing.Optional[AttributeHistogramStatistics] = None
 
 
+class AttributeHistogramList(pydantic.RootModel[list[AttributeHistogram]]):
+    def __iter__(self):
+        return iter(self.root)
+
+    def __getitem__(self, item):
+        return self.root[item]
+
+
 class MediaUploadUrlInfo(pydantic.BaseModel):
     upload_url: str
     media_id: str
     media_url: str
 
 
+class MediaUploadUrlInfoList(pydantic.RootModel[list[MediaUploadUrlInfo]]):
+    def __iter__(self):
+        return iter(self.root)
+
+    def __getitem__(self, item):
+        return self.root[item]
+
+
 class VisualisationUploadUrlInfo(pydantic.BaseModel):
     upload_url: str
     visualisation_id: str
     visualisation_url: str
+
+
+class VisualisationUploadUrlInfoList(
+    pydantic.RootModel[list[VisualisationUploadUrlInfo]]
+):
+    def __iter__(self):
+        return iter(self.root)
+
+    def __getitem__(self, item):
+        return self.root[item]
 
 
 VisualisationUnion = typing.Union[
@@ -980,6 +1030,14 @@ class CreateThumbnailsResponse(ResponseBaseParameters):
     parameters: CreateThumbnailsParameters = pydantic.Field(title="Parameters")
 
 
+class CreateThumbnailsResponseList(pydantic.RootModel[list[CreateThumbnailsResponse]]):
+    def __iter__(self):
+        return iter(self.root)
+
+    def __getitem__(self, item):
+        return self.root[item]
+
+
 class UpdateHistogramsParameters(pydantic.BaseModel):
     dataset_id: str = pydantic.Field(title="Dataset ID")
     subset_ids: typing.Optional[list[str]] = pydantic.Field(
@@ -1034,6 +1092,16 @@ class CreateCropsResponse(ResponseBaseParameters):
     parameters: CreateCropsParameters = pydantic.Field(title="Parameters")
 
 
+class MetadataResponseList(
+    pydantic.RootModel[list[UpdateHistogramsResponse | CreateCropsResponse]]
+):
+    def __iter__(self):
+        return iter(self.root)
+
+    def __getitem__(self, item):
+        return self.root[item]
+
+
 class ProcessingJob(pydantic.BaseModel):
     id: uuid.UUID = pydantic.Field(title="ID")
     status: str = pydantic.Field(title="Status")
@@ -1053,6 +1121,14 @@ class ProcessingJob(pydantic.BaseModel):
     trace_id: typing.Optional[uuid.UUID] = pydantic.Field(
         default=None, title="Trace ID"
     )
+
+
+class ProcessingJobList(pydantic.RootModel[list[ProcessingJob]]):
+    def __iter__(self):
+        return iter(self.root)
+
+    def __getitem__(self, item):
+        return self.root[item]
 
 
 class ProcessingJobStatus(str, enum.Enum):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 
 from hari_client import Config
@@ -120,34 +118,3 @@ def test_get_presigned_visualisation_upload_url_batch_size_range():
             visualisation_config_id="1234",
             batch_size=HARIClient.BULK_UPLOAD_LIMIT + 1,
         )
-
-
-def test_extra_fields_allowed_in_responses():
-    # Arrange
-    hari = HARIClient(config=Config(hari_username="abc", hari_password="123"))
-
-    # patch the response to include an extra field
-    with patch.object(HARIClient, "_request") as mock_request:
-        mock_request.return_value = models.DatasetResponse(
-            id="1234",
-            name="my dataset",
-            parent_dataset="1234",
-            num_medias=0,
-            num_media_objects=0,
-            num_instances=0,
-            done_percentage=None,
-            creation_timestamp=None,
-            color="#FFFFFF",
-            subset_type=None,
-            mediatype=models.MediaType.IMAGE,
-            object_category=None,
-            is_anonymized=None,
-            export_id=None,
-            license=None,
-            visibility_status=models.VisibilityStatus.VISIBLE,
-            extra_field="extra field",
-        )
-
-        # Act + Assert
-        dataset = hari.get_dataset("1234")
-        assert dataset.extra_field == "extra field"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from hari_client import Config
@@ -118,3 +120,34 @@ def test_get_presigned_visualisation_upload_url_batch_size_range():
             visualisation_config_id="1234",
             batch_size=HARIClient.BULK_UPLOAD_LIMIT + 1,
         )
+
+
+def test_extra_fields_allowed_in_responses():
+    # Arrange
+    hari = HARIClient(config=Config(hari_username="abc", hari_password="123"))
+
+    # patch the response to include an extra field
+    with patch.object(HARIClient, "_request") as mock_request:
+        mock_request.return_value = models.DatasetResponse(
+            id="1234",
+            name="my dataset",
+            parent_dataset="1234",
+            num_medias=0,
+            num_media_objects=0,
+            num_instances=0,
+            done_percentage=None,
+            creation_timestamp=None,
+            color="#FFFFFF",
+            subset_type=None,
+            mediatype=models.MediaType.IMAGE,
+            object_category=None,
+            is_anonymized=None,
+            export_id=None,
+            license=None,
+            visibility_status=models.VisibilityStatus.VISIBLE,
+            extra_field="extra field",
+        )
+
+        # Act + Assert
+        dataset = hari.get_dataset("1234")
+        assert dataset.extra_field == "extra field"

--- a/tests/test_parse_response_model.py
+++ b/tests/test_parse_response_model.py
@@ -101,7 +101,11 @@ def test_parse_response_model_works_with_list_of_pydantic_models():
         assert item.media_url == response_data[idx]["media_url"]
 
 
-type_mismatch_error_match = ".Types do not match."
+type_mismatch_error_match = (
+    "The response_data or the response model are not of the expected type"
+)
+none_type_error_match = "Cannot parse None type into a non-None type"
+pydantic_validation_error_match = "Failed to parse response_data into response_model"
 
 
 @pytest.mark.parametrize(
@@ -113,13 +117,13 @@ type_mismatch_error_match = ".Types do not match."
             "hello_world",
             None,
             errors.ParseResponseModelError,
-            type_mismatch_error_match,
+            none_type_error_match,
         ),
         (
             None,
             "hello_world",
             errors.ParseResponseModelError,
-            type_mismatch_error_match,
+            none_type_error_match,
         ),
         (
             [1, 2, 3, {"a": 7}],
@@ -141,7 +145,7 @@ type_mismatch_error_match = ".Types do not match."
             },
             models.VisualisationUploadUrlInfo,
             pydantic.ValidationError,
-            "Failed to parse response_data into response_model.",
+            pydantic_validation_error_match,
         ),
     ],
 )

--- a/tests/test_parse_response_model.py
+++ b/tests/test_parse_response_model.py
@@ -176,3 +176,33 @@ def test_parse_response_model_works_with_pydantic_model_with_root_field_of_list(
     assert response.root[1].x is False
     assert response.root[1].y == [1, 2]
     assert response.root[1].z == {"m": 3}
+
+
+def test_extra_fields_allowed_for_models():
+    # Arrange
+    response_data = models.DatasetResponse(
+        id="1234",
+        name="my dataset",
+        parent_dataset="1234",
+        num_medias=0,
+        num_media_objects=0,
+        num_instances=0,
+        done_percentage=None,
+        creation_timestamp=None,
+        color="#FFFFFF",
+        subset_type=None,
+        mediatype=models.MediaType.IMAGE,
+        object_category=None,
+        is_anonymized=None,
+        export_id=None,
+        license=None,
+        visibility_status=models.VisibilityStatus.VISIBLE,
+        extra_field="extra field",
+    )
+
+    # Act + Assert
+    dataset_response = _parse_response_model(
+        response_data=response_data.model_dump(), response_model=models.DatasetResponse
+    )
+
+    assert dataset_response.extra_field == "extra field"


### PR DESCRIPTION
# Background
Response parser is quite complex. Returning lists, unions or other custom types is confusing.


# Changes
- [Allow extra attributes in responses](https://github.com/quality-match/hari-client/commit/3cc6ec7eb765b43b4f88f3832fa195ee11bb4dcf)
  - added this to any type that looked like it was used for parsing responses to add this information for the user. So far, it was ignored
- [Add models for endpoints returning lists](https://github.com/quality-match/hari-client/commit/13ddb514cfe0f5ef9511268523a8427b281c87fb)
  - add models inheriting from pydantic.Rootmodel to make response parsing easier
- [Update parsing of response models](https://github.com/quality-match/hari-client/commit/b6182b447efb3786315acc93902ea7770f5910ea)
  - make response parsing easier
- [Update create_subset-method to reflect API](https://github.com/quality-match/hari-client/pull/11/commits/0f8a87d05ed7c3d5450cf442718d95ac082b1512)