### PR TITLE
Compatibility updates for hari v7.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,20 @@
 ## [major.minor.patch] - YYYY-MM-DD
 
+## [1.0.0] - YYYY-MM-DD
+
 ### New Features
 
 - added support for media and media object bulk creation endpoints [PR#2](https://github.com/quality-match/hari-client/pull/2)
 - added support for processingJobs endpoints [PR#3](https://github.com/quality-match/hari-client/pull/3)
 - added new hari_uploader interface to simplify the usage of the media and media object creation endpoints [PR#7](https://github.com/quality-match/hari-client/pull/7)
+- added support for new metadata rebuild endpoints. One method is enough to trigger all necessary metadata update prcessing jobs [PR#15](https://github.com/quality-match/hari-client/pull/15)
 
 ### Updates
 
 - update create_subset method: added args `filter_options` and `secondary_filter_options` [PR#14](https://github.com/quality-match/hari-client/pull/14)
 - updated all API models to keep extra fields in the parsed models by using [pydantic model config setting `extra="allow"`](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.extra) [PR#14](https://github.com/quality-match/hari-client/pull/14)
   - this means that if the backend responds with new fields, the response parser doesn't break and the fields that are unknown to the hari-client will still be accessible
+- updated the quickstart example code to use the new hari_uploader interface and the new metadata rebuild endpoint [PR#15](https://github.com/quality-match/hari-client/pull/15)
 
 ### Breaking Changes
 
@@ -18,11 +22,13 @@
   - create_thumbnails --> trigger_thumbnails_creation_job
   - update_histograms --> trigger_histograms_update_job
   - create_crops --> trigger_crops_creation_job
+- Renamed field `customer` of Dataset model and create_dataset endpoint to `user_group` [PR#15](https://github.com/quality-match/hari-client/pull/15)
 
 ### Internal
 
 - updated response parser logic to behave more consistently. If you expect a list from the endpoint, you have to specify the response type as a list as well: `list[MyModel]` [PR#14](https://github.com/quality-match/hari-client/pull/14)
   - previously specifying `MyModel` as response type could've still resulted in parsing the response data to `list[MyModel]` even though this wasn't specified as the expected response type.
+- added new error classes: `ParameterNumberRangeError` and `ParameterListLengthError` [PR#15](https://github.com/quality-match/hari-client/pull/15)
 
 ## [0.2.0] - 2024-08-23
 

--- a/docs/example_code/quickstart.py
+++ b/docs/example_code/quickstart.py
@@ -52,7 +52,6 @@ media_2.add_media_object(
     hari_uploader.HARIMediaObject(
         source=models.DataSource.REFERENCE,
         back_reference="motorcycle_wheel_1",
-        media_type=models.MediaType.IMAGE,
         reference_data=models.Point2DXY(x=975.0, y=2900.0),
     )
 )
@@ -67,7 +66,6 @@ media_3.add_media_object(
     hari_uploader.HARIMediaObject(
         source=models.DataSource.REFERENCE,
         back_reference="road marking",
-        media_type=models.MediaType.IMAGE,
         reference_data=models.PolyLine2DFlatCoordinates(
             coordinates=[1450, 1550, 1450, 1000],
             closed=False,

--- a/docs/example_code/quickstart.py
+++ b/docs/example_code/quickstart.py
@@ -16,8 +16,7 @@ hari = HARIClient(config=config)
 
 # 2. Create a dataset
 # Replace "CHANGEME" with you own user group!
-user_group = "CHANGEME"
-new_dataset = hari.create_dataset(name="My first dataset", customer=user_group)
+new_dataset = hari.create_dataset(name="My first dataset", user_group="CHANGEME")
 print("Dataset created with id:", new_dataset.id)
 
 # 3. Setup your medias and all of their media objects.
@@ -129,8 +128,7 @@ while thumbnails_job_id == "":
         (
             job.id
             for job in jobs
-            if job.process_name
-            == models.ProcessingJobsForMetadataUpdate.THUMBNAILS_CREATION
+            if job.process_name == models.ProcessingJobMethods.THUMBNAILS_CREATION
         ),
         "",
     )

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -1418,7 +1418,9 @@ class HARIClient:
         dataset_id: str,
         trace_id: typing.Optional[str] = None,
         compute_for_all_subsets: typing.Optional[bool] = False,
-    ) -> models.UpdateHistogramsResponse:
+    ) -> list[
+        models.UpdateHistogramsResponse | models.CalculateSubAndDatasetCountsResponse
+    ]:
         """Triggers the update of the histograms for a given dataset.
 
         Args:
@@ -1441,7 +1443,10 @@ class HARIClient:
             "PUT",
             f"/datasets/{dataset_id}/histograms",
             params=params,
-            success_response_item_model=models.UpdateHistogramsResponse,
+            success_response_item_model=list[
+                models.UpdateHistogramsResponse
+                | models.CalculateSubAndDatasetCountsResponse
+            ],
         )
 
     def trigger_crops_creation_job(
@@ -1453,9 +1458,7 @@ class HARIClient:
         max_size: typing.Optional[tuple[int]] = None,
         padding_minimum: typing.Optional[int] = None,
         padding_percent: typing.Optional[int] = None,
-    ) -> list[
-        typing.Union[models.UpdateHistogramsResponse, models.CreateCropsResponse],
-    ]:
+    ) -> list[models.UpdateHistogramsResponse | models.CreateCropsResponse]:
         """Creates the crops for a given dataset if the correct api key is provided in the
 
         Args:
@@ -1484,9 +1487,7 @@ class HARIClient:
             params=params,
             json=self._pack(locals(), ignore=["dataset_id", "subset_id", "trace_id"]),
             success_response_item_model=list[
-                typing.Union[
-                    models.UpdateHistogramsResponse, models.CreateCropsResponse
-                ],
+                models.UpdateHistogramsResponse | models.CreateCropsResponse
             ],
         )
 

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -1,5 +1,6 @@
 import datetime
 import pathlib
+import types
 import typing
 
 import pydantic
@@ -69,7 +70,8 @@ def _parse_response_model(
         if origin is list:
             item_type = typing.get_args(response_model)[0]
             if isinstance(response_data, list):
-                if typing.get_origin(item_type) is typing.Union:
+                origin = typing.get_origin(item_type)
+                if origin in [typing.Union, types.UnionType]:
                     return [
                         handle_union_parsing(item, item_type) for item in response_data
                     ]

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -1529,12 +1529,16 @@ class HARIClient:
         Returns:
             The methods being executed
         """
+        params = {}
+        if subset_id:
+            params["subset_id"] = subset_id
+        if trace_id:
+            params["trace_id"] = trace_id
+
         return self._request(
             "PUT",
             f"/datasets/{dataset_id}/metadata",
-            params={"subset_id": subset_id},
-            # note: the backend expects the trace_id as body, not a json object
-            json=trace_id,
+            params=params,
             success_response_item_model=list[models.BaseProcessingJobMethod],
         )
 

--- a/hari_client/client/errors.py
+++ b/hari_client/client/errors.py
@@ -60,14 +60,27 @@ class BulkUploadSizeRangeError(Exception):
         )
 
 
-class ParameterRangeError(Exception):
+class ParameterNumberRangeError(Exception):
+    def __init__(
+        self,
+        param_name: str,
+        minimum: int | float,
+        maximum: int | float,
+        value: int | float,
+    ):
+        super().__init__(
+            f"The valid range for the {param_name} parameter is: {minimum=}, {maximum=}, but actual value is {value=}"
+        )
+
+
+class ParameterListLengthError(Exception):
     def __init__(
         self,
         param_name: str,
         minimum: int,
         maximum: int,
-        value: int,
+        length: int,
     ):
         super().__init__(
-            f"The valid range for the {param_name} parameter is: {minimum=}, {maximum=}, but found {value} items"
+            f"The valid length for the {param_name} parameter is: {minimum=}, {maximum=}, but actual length is {length=}"
         )

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -240,7 +240,7 @@ class Dataset(BaseModel):
     data_root: str = pydantic.Field(title="Data Root")
     creation_timestamp: str = pydantic.Field(title="Creation Timestamp")
     mediatype: MediaType = pydantic.Field(title="MediaType")
-    customer: typing.Optional[str] = pydantic.Field(default=None, title="Customer")
+    user_group: typing.Optional[str] = pydantic.Field(default=None, title="User Group")
     reference_files: typing.Optional[list] = pydantic.Field(
         default=None, title="Reference Files"
     )
@@ -274,6 +274,7 @@ class DatasetResponse(BaseModel):
     parent_dataset: typing.Optional[str] = pydantic.Field(
         default=None, title="Parent Dataset"
     )
+    user_group: typing.Optional[str] = pydantic.Field(default=None, title="User Group")
     num_medias: int = pydantic.Field(title="Num Medias")
     num_media_objects: int = pydantic.Field(title="Num Media Objects")
     num_instances: int = pydantic.Field(title="Num Instances")
@@ -931,119 +932,10 @@ class ProcessingType(str, enum.Enum):
     REMOTE = "remote"
 
 
-class ProcessingJobsForMetadataUpdate(str, enum.Enum):
+class ProcessingJobMethods(str, enum.Enum):
     THUMBNAILS_CREATION = "create_thumbnails"
     HISTOGRAMS_UPDATE = "update_histograms"
     CROPS_CREATION = "create_crops"
-
-
-class ProcessingJobResponseBaseParameters(BaseModel):
-    batch: bool = pydantic.Field(default=False, title="Batch")
-    override_processing_type: typing.Optional[ProcessingType] = pydantic.Field(
-        default=None, title="Override Processing Type"
-    )
-    task_token: typing.Optional[str] = pydantic.Field(default=None, title="Task Token")
-    job_id: typing.Optional[uuid.UUID] = pydantic.Field(default=None, title="Job ID")
-    trace_id: typing.Optional[uuid.UUID] = pydantic.Field(
-        default=None, title="Trace ID"
-    )
-    user_id: typing.Optional[uuid.UUID] = pydantic.Field(default=None, title="User ID")
-    user_group: typing.Optional[str] = pydantic.Field(default=None, title="User Group")
-
-
-class CreateThumbnailsParameters(BaseModel):
-    dataset_id: str = pydantic.Field(title="Dataset ID")
-    query: typing.Optional[QueryList] = pydantic.Field(default=None, title="Query")
-    pagination: typing.Optional[PaginationParameter] = pydantic.Field(
-        default=None, title="Pagination"
-    )
-    upload_folder_name: str = pydantic.Field(
-        default="thumbnails", title="Upload Folder Name"
-    )
-    s3_bucket: typing.Optional[str] = pydantic.Field(default=None, title="S3 Bucket")
-    s3_folder: typing.Optional[str] = pydantic.Field(default=None, title="S3 Folder")
-    max_size: typing.Optional[tuple[int, int]] = pydantic.Field(
-        default=None, title="Max Size"
-    )
-    aspect_ratio: tuple[int, int] = pydantic.Field(title="Aspect Ratio")
-    calc_and_write_image_info: bool = pydantic.Field(
-        default=True, title="Calculate and Write Image Info"
-    )
-
-
-class CreateThumbnailsResponse(ProcessingJobResponseBaseParameters):
-    method_name: typing.Literal[
-        ProcessingJobsForMetadataUpdate.THUMBNAILS_CREATION
-    ] = pydantic.Field(
-        default=ProcessingJobsForMetadataUpdate.THUMBNAILS_CREATION,
-        title="Method Name",
-    )
-    parameters: CreateThumbnailsParameters = pydantic.Field(title="Parameters")
-
-
-class UpdateHistogramsParameters(BaseModel):
-    dataset_id: str = pydantic.Field(title="Dataset ID")
-    subset_ids: typing.Optional[list[str]] = pydantic.Field(
-        default=None, title="Subset IDs"
-    )
-    attribute_ids: typing.Optional[list[str]] = pydantic.Field(
-        default=None, title="Attribute IDs"
-    )
-    num_buckets: int = pydantic.Field(default=360, title="Number of Buckets")
-    ignore_complete_dataset_histogram: bool = pydantic.Field(
-        default=False, title="Ignore Complete Dataset Histogram"
-    )
-    compute_for_all_subsets: bool = pydantic.Field(
-        default=False, title="Compute for All Subsets"
-    )
-
-
-class UpdateHistogramsResponse(ProcessingJobResponseBaseParameters):
-    method_name: typing.Literal[
-        ProcessingJobsForMetadataUpdate.HISTOGRAMS_UPDATE
-    ] = pydantic.Field(
-        default=ProcessingJobsForMetadataUpdate.HISTOGRAMS_UPDATE,
-        title="Method Name",
-    )
-    parameters: UpdateHistogramsParameters = pydantic.Field(title="Parameters")
-
-
-class CreateCropsParameters(BaseModel):
-    dataset_id: str = pydantic.Field(title="Dataset ID")
-    query: typing.Optional[QueryList] = pydantic.Field(default=None, title="Query")
-    pagination: typing.Optional[PaginationParameter] = pydantic.Field(
-        default=None, title="Pagination"
-    )
-    upload_folder_name: str = pydantic.Field(
-        default="cropped_image", title="Upload Folder Name"
-    )
-    s3_bucket: typing.Optional[str] = pydantic.Field(default=None, title="S3 Bucket")
-    s3_folder: typing.Optional[str] = pydantic.Field(default=None, title="S3 Folder")
-    aspect_ratio: tuple[int, int] = pydantic.Field(title="Aspect Ratio")
-    padding_percent: int = pydantic.Field(title="Padding Percent")
-    padding_minimum: int = pydantic.Field(title="Padding Minimum")
-    max_size: typing.Optional[tuple[int, int]] = pydantic.Field(
-        default=None, title="Max Size"
-    )
-
-
-class CreateCropsResponse(ProcessingJobResponseBaseParameters):
-    method_name: typing.Literal[
-        ProcessingJobsForMetadataUpdate.CROPS_CREATION
-    ] = pydantic.Field(
-        default=ProcessingJobsForMetadataUpdate.CROPS_CREATION, title="Method Name"
-    )
-    parameters: CreateCropsParameters = pydantic.Field(title="Parameters")
-
-
-class CalculateSubAndDatasetCountsParameters(BaseModel):
-    dataset_id: uuid.UUID
-
-
-class CalculateSubAndDatasetCountsResponse(ProcessingJobResponseBaseParameters):
-    method_name: typing.Literal[
-        "calculate_sub_and_dataset_counts"
-    ] = "calculate_sub_and_dataset_counts"
 
 
 class ProcessingJob(BaseModel):
@@ -1072,3 +964,20 @@ class ProcessingJobStatus(str, enum.Enum):
     RUNNING = "running"
     SUCCESS = "success"
     FAILED = "failed"
+
+
+class BaseProcessingJobParameters(BaseModel):
+    # this is intentionally left empty to allow for arbitrary parameters
+    pass
+
+
+class BaseProcessingJobMethod(BaseModel):
+    method_name: str
+    batch: bool = False
+    override_processing_type: ProcessingType | None = None
+    task_token: str | None = None
+    job_id: uuid.UUID | None = None
+    trace_id: uuid.UUID | None = None
+    user_id: uuid.UUID | None = None
+    user_group: str | None = None
+    parameters: BaseProcessingJobParameters

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -936,11 +936,19 @@ class ProcessingJobMethods(str, enum.Enum):
     THUMBNAILS_CREATION = "create_thumbnails"
     HISTOGRAMS_UPDATE = "update_histograms"
     CROPS_CREATION = "create_crops"
+    METADATA_REBUILD = "metadata_rebuild"
+
+
+class ProcessingJobStatus(str, enum.Enum):
+    CREATED = "created"
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILED = "failed"
 
 
 class ProcessingJob(BaseModel):
     id: uuid.UUID = pydantic.Field(title="ID")
-    status: str = pydantic.Field(title="Status")
+    status: ProcessingJobStatus = pydantic.Field(title="Status")
     owner: typing.Optional[uuid.UUID] = pydantic.Field(default=None, title="Owner")
     user_group: typing.Optional[str] = pydantic.Field(default=None, title="User Group")
     created_at: typing.Optional[datetime.datetime] = pydantic.Field(
@@ -957,13 +965,6 @@ class ProcessingJob(BaseModel):
     trace_id: typing.Optional[uuid.UUID] = pydantic.Field(
         default=None, title="Trace ID"
     )
-
-
-class ProcessingJobStatus(str, enum.Enum):
-    CREATED = "created"
-    RUNNING = "running"
-    SUCCESS = "success"
-    FAILED = "failed"
 
 
 class BaseProcessingJobParameters(BaseModel):

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -937,7 +937,7 @@ class ProcessingJobsForMetadataUpdate(str, enum.Enum):
     CROPS_CREATION = "create_crops"
 
 
-class ResponseBaseParameters(BaseModel):
+class ProcessingJobResponseBaseParameters(BaseModel):
     batch: bool = pydantic.Field(default=False, title="Batch")
     override_processing_type: typing.Optional[ProcessingType] = pydantic.Field(
         default=None, title="Override Processing Type"
@@ -971,7 +971,7 @@ class CreateThumbnailsParameters(BaseModel):
     )
 
 
-class CreateThumbnailsResponse(ResponseBaseParameters):
+class CreateThumbnailsResponse(ProcessingJobResponseBaseParameters):
     method_name: typing.Literal[
         ProcessingJobsForMetadataUpdate.THUMBNAILS_CREATION
     ] = pydantic.Field(
@@ -998,7 +998,7 @@ class UpdateHistogramsParameters(BaseModel):
     )
 
 
-class UpdateHistogramsResponse(ResponseBaseParameters):
+class UpdateHistogramsResponse(ProcessingJobResponseBaseParameters):
     method_name: typing.Literal[
         ProcessingJobsForMetadataUpdate.HISTOGRAMS_UPDATE
     ] = pydantic.Field(
@@ -1027,7 +1027,7 @@ class CreateCropsParameters(BaseModel):
     )
 
 
-class CreateCropsResponse(ResponseBaseParameters):
+class CreateCropsResponse(ProcessingJobResponseBaseParameters):
     method_name: typing.Literal[
         ProcessingJobsForMetadataUpdate.CROPS_CREATION
     ] = pydantic.Field(

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -297,7 +297,7 @@ class DatasetResponse(BaseModel):
     export_id: typing.Optional[str] = pydantic.Field(default=None, title="Export Id")
     license: typing.Optional[str] = pydantic.Field(default=None, title="License")
     visibility_status: typing.Optional[VisibilityStatus] = pydantic.Field(
-        default="visible", title="VisibilityStatus"
+        default=VisibilityStatus.VISIBLE, title="VisibilityStatus"
     )
 
 

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -1036,6 +1036,16 @@ class CreateCropsResponse(ProcessingJobResponseBaseParameters):
     parameters: CreateCropsParameters = pydantic.Field(title="Parameters")
 
 
+class CalculateSubAndDatasetCountsParameters(BaseModel):
+    dataset_id: uuid.UUID
+
+
+class CalculateSubAndDatasetCountsResponse(ProcessingJobResponseBaseParameters):
+    method_name: typing.Literal[
+        "calculate_sub_and_dataset_counts"
+    ] = "calculate_sub_and_dataset_counts"
+
+
 class ProcessingJob(BaseModel):
     id: uuid.UUID = pydantic.Field(title="ID")
     status: str = pydantic.Field(title="Status")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -83,14 +83,17 @@ def test_get_presigned_media_upload_url_batch_size_range():
     hari = HARIClient(config=Config(hari_username="abc", hari_password="123"))
 
     # Act + Assert
-    with pytest.raises(errors.ParameterRangeError):
+    with pytest.raises(errors.ParameterNumberRangeError, match="value=0"):
         hari.get_presigned_media_upload_url(
             dataset_id="1234",
             file_extension=".jpg",
             batch_size=0,
         )
 
-    with pytest.raises(errors.ParameterRangeError):
+    with pytest.raises(
+        errors.ParameterNumberRangeError,
+        match=f"value={HARIClient.BULK_UPLOAD_LIMIT + 1}",
+    ):
         hari.get_presigned_media_upload_url(
             dataset_id="1234",
             file_extension=".jpg",
@@ -103,7 +106,7 @@ def test_get_presigned_visualisation_upload_url_batch_size_range():
     hari = HARIClient(config=Config(hari_username="abc", hari_password="123"))
 
     # Act + Assert
-    with pytest.raises(errors.ParameterRangeError):
+    with pytest.raises(errors.ParameterNumberRangeError, match="value=0"):
         hari.get_presigned_visualisation_upload_url(
             dataset_id="1234",
             file_extension=".jpg",
@@ -111,10 +114,29 @@ def test_get_presigned_visualisation_upload_url_batch_size_range():
             batch_size=0,
         )
 
-    with pytest.raises(errors.ParameterRangeError):
+    with pytest.raises(
+        errors.ParameterNumberRangeError,
+        match=f"value={HARIClient.BULK_UPLOAD_LIMIT + 1}",
+    ):
         hari.get_presigned_visualisation_upload_url(
             dataset_id="1234",
             file_extension=".jpg",
             visualisation_config_id="1234",
             batch_size=HARIClient.BULK_UPLOAD_LIMIT + 1,
+        )
+
+
+def test_trigger_metadata_rebuild_validation_for_dataset_ids_list():
+    # Arrange
+    hari = HARIClient(config=Config(hari_username="abc", hari_password="123"))
+
+    # Act + Assert
+    with pytest.raises(errors.ParameterListLengthError, match="length=0"):
+        hari.trigger_metadata_rebuild_job(
+            dataset_ids=[],
+        )
+
+    with pytest.raises(errors.ParameterListLengthError, match="length=11"):
+        hari.trigger_metadata_rebuild_job(
+            dataset_ids=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,7 +11,7 @@ def test_media_create_ignores_file_path_when_parsed_or_serialized():
     )
 
     # Act
-    media_create_dict = media_create.dict()
+    media_create_dict = media_create.model_dump()
     media_create_from_dict = models.MediaCreate(**media_create_dict)
 
     # Assert

--- a/tests/test_parse_response_model.py
+++ b/tests/test_parse_response_model.py
@@ -187,6 +187,11 @@ def test_parse_response_model_works_with_dict_of_parametrized_generics(
             list[typing.Union[SimpleModel1, ComplexModelWithNestedListOfUnions]],
             [SimpleModel1, ComplexModelWithNestedListOfUnions],
         ),
+        (
+            [TestObject1, {"i": 2, "k": [TestObject1, TestObject2]}],
+            list[SimpleModel1 | ComplexModelWithNestedListOfUnions],
+            [SimpleModel1, ComplexModelWithNestedListOfUnions],
+        ),
     ],
 )
 def test_parse_response_model_works_with_list_of_unions(


### PR DESCRIPTION
1610400640

This PR adds compatibility updates for HARI backend version 7.0.3.
- added support for new metadata rebuild endpoints. One method is enough to trigger all necessary metadata update prcessing jobs
- updated the quickstart example code to use the new hari_uploader interface and the new metadata rebuild endpoint
- renamed field `customer` of Dataset model and create_dataset endpoint to `user_group`
- added new error classes: `ParameterNumberRangeError` and `ParameterListLengthError`
- the api response model for the processing jobs changed from unions of specific models to only being a generic model 