### PR TITLE
Update hari uploader interface to use bulk_operation_annotatable_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [major.minor.patch] - YYYY-MM-DD
 
-## [1.0.0] - YYYY-MM-DD
+## [1.0.0] - 27.09.2024
 
 ### New Features
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Minimum python version: **3.11**
 To install the hari-client package, use pip with the following command:
 
 ```bash
-python -m pip install "hari_client @ git+https://github.com/quality-match/hari-client@v0.2.0"
+python -m pip install "hari_client @ git+https://github.com/quality-match/hari-client@v1.0.0"
 ```
 
 ## Quickstart

--- a/docs/example_code/quickstart.py
+++ b/docs/example_code/quickstart.py
@@ -109,18 +109,17 @@ print(f"Created new subset with id {new_subset_id}")
 # 7. Trigger metadata updates
 print("Triggering metadata updates...")
 # create a trace_id to track triggered metadata update jobs
-trace_id = str(uuid.uuid4())
-print(f"metadata_rebuild jobs trace_id: {trace_id}")
+metadata_rebuild_trace_id = str(uuid.uuid4())
+print(f"metadata_rebuild jobs trace_id: {metadata_rebuild_trace_id}")
 metadata_rebuild_jobs = hari.trigger_dataset_metadata_rebuild_job(
-    dataset_id=new_dataset.id, trace_id=trace_id
+    dataset_id=new_dataset.id, trace_id=metadata_rebuild_trace_id
 )
 
 # track the status of all metadata rebuild jobs and wait for them to finish
-job_ids = [job.job_id for job in metadata_rebuild_jobs]
 job_statuses = []
 jobs_are_still_running = True
 while jobs_are_still_running:
-    jobs = [hari.get_processing_job(processing_job_id=job_id) for job_id in job_ids]
+    jobs = hari.get_processing_jobs(trace_id=metadata_rebuild_trace_id)
     job_statuses = [(job.id, job.status) for job in jobs]
 
     jobs_are_still_running = any(

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -611,7 +611,7 @@ class HARIClient:
         )
 
     def create_medias(
-        self, dataset_id: str, medias: list[models.MediaCreate]
+        self, dataset_id: str, medias: list[models.BulkMediaCreate]
     ) -> models.BulkResponse:
         """Accepts multiple files, uploads them, and creates the medias in the db.
         The limit is 500 per call.
@@ -1111,7 +1111,7 @@ class HARIClient:
     def create_media_objects(
         self,
         dataset_id: str,
-        media_objects: list[models.MediaObjectCreate],
+        media_objects: list[models.BulkMediaObjectCreate],
     ) -> models.BulkResponse:
         """Creates new media_objects in the database. The limit is 500 per call.
 

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -540,10 +540,19 @@ class HARIClient:
         Raises:
             APIException: If the request fails.
         """
+        body = {}
+        if filter_options:
+            body["filter_options"] = filter_options
+        if secondary_filter_options:
+            body["secondary_filter_options"] = secondary_filter_options
+
         return self._request(
             "POST",
             f"/subsets:createFiltered",
-            params=self._pack(locals()),
+            params=self._pack(
+                locals(), ignore=["filter_options", "secondary_filter_options"]
+            ),
+            json=body,
             success_response_item_model=str,
         )
 

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -865,7 +865,7 @@ class BaseBulkItemResponse(BaseModel, arbitrary_types_allowed=True):
 
 
 class AnnotatableCreateResponse(BaseBulkItemResponse):
-    back_reference: str
+    bulk_operation_annotatable_id: str
 
 
 class AttributeCreateResponse(BaseBulkItemResponse):
@@ -879,7 +879,7 @@ class BulkResponse(BaseModel):
     )
     results: list[
         typing.Union[
-            BaseBulkItemResponse, AnnotatableCreateResponse, AttributeCreateResponse
+            AnnotatableCreateResponse, AttributeCreateResponse, BaseBulkItemResponse
         ]
     ] = pydantic.Field(default_factory=list)
 
@@ -905,6 +905,10 @@ class MediaCreate(BaseModel):
     back_reference_json: typing.Optional[str] = None
 
 
+class BulkMediaCreate(MediaCreate):
+    bulk_operation_annotatable_id: str
+
+
 class MediaObjectCreate(BaseModel):
     media_id: str
     source: DataSource
@@ -925,6 +929,10 @@ class MediaObjectCreate(BaseModel):
     reference_data: typing.Optional[GeometryUnion] = None
     frame_idx: typing.Optional[int] = None
     media_object_type: typing.Optional[GeometryUnion] = None
+
+
+class BulkMediaObjectCreate(MediaObjectCreate):
+    bulk_operation_annotatable_id: str
 
 
 class ProcessingType(str, enum.Enum):

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -16,12 +16,12 @@ class HARIMediaObject(models.BulkMediaObjectCreate):
     media_id: str = ""
     # overwrites the bulk_operation_annotatable_id field to not be required,
     # because it's set internally by the HARIUploader
-    bulk_operation_annotatable_id: str = ""
+    bulk_operation_annotatable_id: str | None = None
 
     @pydantic.field_validator("media_id", "bulk_operation_annotatable_id")
     @classmethod
     def field_must_not_be_set(cls, v: str) -> str:
-        if "" != v:
+        if v:
             raise ValueError(
                 "The field must not be set on object instantiation. It's used and set by HARIUploader internals."
             )
@@ -47,7 +47,7 @@ class HARIMedia(models.BulkMediaCreate):
     media_objects: list[HARIMediaObject] = pydantic.Field(default=[], exclude=True)
     # overwrites the bulk_operation_annotatable_id field to not be required,
     # because it's set internally by the HARIUploader
-    bulk_operation_annotatable_id: str = ""
+    bulk_operation_annotatable_id: str | None = ""
 
     def add_media_object(self, *args: HARIMediaObject) -> None:
         for media_object in args:
@@ -56,7 +56,7 @@ class HARIMedia(models.BulkMediaCreate):
     @pydantic.field_validator("bulk_operation_annotatable_id")
     @classmethod
     def field_must_not_be_set(cls, v: str) -> str:
-        if "" != v:
+        if v:
             raise ValueError(
                 "The field must not be set on object instantiation. It's used and set by HARIUploader internals."
             )
@@ -161,7 +161,6 @@ class HARIUploader:
     def _upload_media_batch(
         self, medias_to_upload: list[HARIMedia]
     ) -> tuple[models.BulkResponse, list[models.BulkResponse]]:
-        # set bulk_operation_annotatable_id for all medias_to_upload
         for media in medias_to_upload:
             self._set_bulk_operation_annotatable_id(item=media)
 
@@ -202,7 +201,6 @@ class HARIUploader:
     def _upload_media_object_batch(
         self, media_objects_to_upload: list[HARIMediaObject]
     ) -> models.BulkResponse:
-        # set bulk_operation_annotatable_id for all media_objects_to_upload
         for media_object in media_objects_to_upload:
             self._set_bulk_operation_annotatable_id(item=media_object)
         response = self.client.create_media_objects(

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="hari_client",
-    version="0.2.0",
+    version="1.0.0",
     description="A Python client for the HARI API",
     author="Quality Match GmbH",
     author_email="info@quality-match.com",


### PR DESCRIPTION
- Back references aren't required to be unique anymore. Empty and duplicate back_references will log a warning though
- Back references aren't used in the bulk media and media_object upload endpoints anymore. Instead a randomly generated and temporary bulk_operation_annotatable_id is used
- Update quickstart script to fetch processing jobs via trace_id