### PR TITLE
Setup of object category subsets in hari uploader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### New Features
 
+- added support for object categories [PR#26](https://github.com/quality-match/hari-client/pull/26)
 - added support for attributes bulk upload with hari-uploader [PR#17](https://github.com/quality-match/hari-client/pull/17)
 - added support for Attribute endpoints to client [PR#18](https://github.com/quality-match/hari-client/pull/18)
 

--- a/docs/example_code/quickstart.py
+++ b/docs/example_code/quickstart.py
@@ -25,6 +25,7 @@ dataset_id = new_dataset.id
 # In this example we use 3 images with 1 media object each.
 # The first media and media object have 1 attribute each.
 media_1 = hari_uploader.HARIMedia(
+    # note: the file_path won't be saved in HARI, it's only used during uploading
     file_path="images/image_1.jpg",
     name="A busy street 1",
     back_reference="image 1",

--- a/docs/example_code/quickstart.py
+++ b/docs/example_code/quickstart.py
@@ -94,7 +94,7 @@ media_3.add_media_object(media_object_3)
 uploader = hari_uploader.HARIUploader(
     client=hari,
     dataset_id=dataset_id,
-    object_categories=set(["pedestrian", "wheel", "road_marking"]),
+    object_categories_to_validate={"pedestrian", "wheel", "road_marking"},
 )
 uploader.add_media(media_1, media_2, media_3)
 

--- a/docs/example_code/quickstart.py
+++ b/docs/example_code/quickstart.py
@@ -94,7 +94,7 @@ media_3.add_media_object(media_object_3)
 uploader = hari_uploader.HARIUploader(
     client=hari,
     dataset_id=dataset_id,
-    object_categories_to_validate={"pedestrian", "wheel", "road_marking"},
+    object_categories={"pedestrian", "wheel", "road_marking"},
 )
 uploader.add_media(media_1, media_2, media_3)
 

--- a/docs/example_code/quickstart.py
+++ b/docs/example_code/quickstart.py
@@ -57,6 +57,7 @@ attribute_media_1 = hari_uploader.HARIAttribute(
 )
 media_1.add_attribute(attribute_media_1)
 media_object_1.add_attribute(attribute_object_1)
+media_object_1.set_object_category_subset_name("pedestrian")
 media_1.add_media_object(media_object_1)
 
 media_object_2 = hari_uploader.HARIMediaObject(
@@ -69,6 +70,7 @@ media_2 = hari_uploader.HARIMedia(
     back_reference="image 2",
     media_type=models.MediaType.IMAGE,
 )
+media_object_2.set_object_category_subset_name("wheel")
 media_2.add_media_object(media_object_2)
 
 media_3 = hari_uploader.HARIMedia(
@@ -84,10 +86,15 @@ media_object_3 = hari_uploader.HARIMediaObject(
         closed=False,
     ),
 )
+media_object_3.set_object_category_subset_name("road_marking")
 media_3.add_media_object(media_object_3)
 
 # 4. Set up the uploader and add the medias to it
-uploader = hari_uploader.HARIUploader(client=hari, dataset_id=dataset_id)
+uploader = hari_uploader.HARIUploader(
+    client=hari,
+    dataset_id=dataset_id,
+    object_categories=set(["pedestrian", "wheel", "road_marking"]),
+)
 uploader.add_media(media_1, media_2, media_3)
 
 # 5. Trigger the upload process

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -866,7 +866,7 @@ class MediaObjectCreate(BaseModel):
     scene_id: str | None = None
     realWorldObject_id: str | None = None
     visualisations: list[VisualisationUnion] | None = None
-    subset_ids: set[str] | list[str] | None = None
+    subset_ids: list[str] | None = None
 
     instance_id: str | None = None
     object_category: str | None = None

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -866,7 +866,7 @@ class MediaObjectCreate(BaseModel):
     scene_id: str | None = None
     realWorldObject_id: str | None = None
     visualisations: list[VisualisationUnion] | None = None
-    subset_ids: list[str] | None = None
+    subset_ids: set[str] | list[str] | None = None
 
     instance_id: str | None = None
     object_category: str | None = None

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -126,7 +126,6 @@ class HARIUploader:
     ) -> None:
         self.client: HARIClient = client
         self.dataset_id: str = dataset_id
-        self.object_categories: set[str] = set()
         self.object_categories_to_validate = object_categories_to_validate or set()
         self._medias: list[HARIMedia] = []
         self._media_back_references: set[str] = set()
@@ -220,7 +219,7 @@ class HARIUploader:
                             errors.append(
                                 HARIMediaObjectUnknownObjectCategorySubsetNameError(
                                     f"A subset for the specified object_category_subset_name ({media_object.object_category_subset_name}) wasn't specified."
-                                    f"Only the object_categories that were specified in the HARIUploader constructor are allowed: {self.object_categories}"
+                                    f"Only the object_categories that were specified in the HARIUploader constructor are allowed: {self.object_categories_to_validate}"
                                     f"media_object: {media_object}"
                                 )
                             )
@@ -242,7 +241,7 @@ class HARIUploader:
                         if media_object.object_category is None:
                             raise HARIMediaObjectUnknownObjectCategorySubsetNameError(
                                 f"A subset for the specified object_category_subset_name ({media_object.object_category_subset_name}) wasn't created."
-                                f"Only the object_categories that were specified in the HARIUploader constructor are allowed: {self.object_categories}"
+                                f"Only the object_categories that were specified in the HARIUploader constructor are allowed: {self.object_categories_to_validate}"
                                 f"media_object: {media_object}"
                             )
                         # also add the object_category subset_id to the overall list of subset_ids
@@ -292,7 +291,6 @@ class HARIUploader:
                 f"Found {len(media_object_object_category_subset_errors)} errors with object_category_subset_name consistency."
             )
             raise media_object_object_category_subset_errors
-        # TODO: also validate that each media has the object_category_subset_names of its medias
 
         object_category_subsets = self._get_existing_object_category_subsets()
         # add already existing subsets to the object_category_subsets dict

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -122,11 +122,11 @@ class HARIUploader:
         self,
         client: HARIClient,
         dataset_id: uuid.UUID,
-        object_categories: set[str] | None = None,
+        object_categories: set[str] = [],
     ) -> None:
         self.client: HARIClient = client
         self.dataset_id: str = dataset_id
-        self.object_categories: set[str] | None = object_categories
+        self.object_categories: set[str] = object_categories
         self._medias: list[HARIMedia] = []
         self._media_back_references: set[str] = set()
         self._media_object_back_references: set[str] = set()
@@ -282,6 +282,9 @@ class HARIUploader:
                 f"Found {len(media_object_object_category_subset_errors)} errors with object_category_subset_name consistency."
             )
             raise media_object_object_category_subset_errors
+        # TODO: also validate that for each object_category specified in the hari_uploader-init, there exists at least one media_object and media for it
+
+        # TODO: also validate that each media has the object_category_subset_names of its medias
         object_category_subsets = self._get_existing_object_category_subsets()
         # add already existing subsets to the object_category_subsets dict
         for obj_category_subset in object_category_subsets:

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -268,6 +268,14 @@ class HARIUploader:
         log.info(f"All existing object_category subsets: {object_category_subsets=}")
         return object_category_subsets
 
+    def get_distinct_subset_names_from_added_media_objects(self) -> set[str]:
+        return {
+            media_obj.object_category_subset_name
+            for medias in self._medias
+            for media_obj in medias.media_objects
+            if media_obj.object_category_subset_name is not None
+        }
+
     def _handle_object_categories(self) -> None:
         """
         Validates consistency of object_categories across media objects,
@@ -284,20 +292,23 @@ class HARIUploader:
                 f"Found {len(media_object_object_category_subset_errors)} errors with object_category_subset_name consistency."
             )
             raise media_object_object_category_subset_errors
-        # TODO: also validate that for each object_category specified in the hari_uploader-init, there exists at least one media_object and media for it
-
         # TODO: also validate that each media has the object_category_subset_names of its medias
+
         object_category_subsets = self._get_existing_object_category_subsets()
         # add already existing subsets to the object_category_subsets dict
         for obj_category_subset in object_category_subsets:
             self._add_object_category_subset(
                 obj_category_subset.name, obj_category_subset.id
             )
+
+        distinct_subset_names = (
+            self.get_distinct_subset_names_from_added_media_objects()
+        )
         # check whether all required object_category subsets already exist
         object_categories_without_existing_subsets = [
-            obj_cat
-            for obj_cat in self.object_categories
-            if obj_cat
+            subset_name
+            for subset_name in distinct_subset_names
+            if subset_name
             not in [obj_cat_subset.name for obj_cat_subset in object_category_subsets]
         ]
 

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -283,14 +283,6 @@ class HARIUploader:
         log.info(f"All existing object_category subsets: {object_category_subsets=}")
         return object_category_subsets
 
-    def get_distinct_subset_names_from_added_media_objects(self) -> set[str]:
-        return {
-            media_obj.object_category_subset_name
-            for medias in self._medias
-            for media_obj in medias.media_objects
-            if media_obj.object_category_subset_name is not None
-        }
-
     def _handle_object_categories(self) -> None:
         """
         Validates consistency of object_categories across media objects,

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -236,6 +236,13 @@ class HARIUploader:
                             media_object.subset_ids.append(media_object.object_category)
                         else:
                             media_object.subset_ids = [media_object.object_category]
+                        # also add the object_category subset_id to the overall list of subset_ids for the media
+                        if media.subset_ids:
+                            media.subset_ids.append(media_object.object_category)
+                        else:
+                            media.subset_ids = [media_object.object_category]
+                        # avoid duplicates in the subset_ids list
+                        media.subset_ids = list(set(media.subset_ids))
 
     def upload(
         self,

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -174,7 +174,8 @@ class HARIUploader:
                 self._attribute_cnt += len(media_object.attributes)
 
     def _create_object_category_subsets(self) -> None:
-        for object_category in self.object_categories:
+        # sort object_categories to ensure consistent subset creation order
+        for object_category in sorted(self.object_categories):
             subset_id = self.client.create_subset(
                 dataset_id=self.dataset_id,
                 subset_type=models.SubsetType.MEDIA_OBJECT,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,9 @@ setup(
         "pydantic-settings>=2.3",
         "tqdm~=4.66",
     ],
-    extras_require={"tests": ["pytest", "pytest-mock", "pre-commit"]},
+    extras_require={
+        "tests": ["pytest", "pytest-mock", "pytest-fixtures", "pre-commit"]
+    },
     classifiers=[
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3.11",

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,7 @@ setup(
         "pydantic-settings>=2.3",
         "tqdm~=4.66",
     ],
-    extras_require={
-        "tests": ["pytest", "pytest-mock", "pytest-fixtures", "pre-commit"]
-    },
+    extras_require={"tests": ["pytest", "pytest-mock", "pre-commit"]},
     classifiers=[
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3.11",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ pytest_plugins = [
 
 
 @pytest.fixture()
-def test_client() -> HARIClient:
+def test_client():
     test_config = Config(
         hari_username="username",
         hari_password="password",
@@ -17,4 +17,4 @@ def test_client() -> HARIClient:
         hari_client_id="client_id",
         hari_auth_url="auth_url",
     )
-    return HARIClient(config=test_config)
+    yield HARIClient(config=test_config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,7 @@ import pytest
 
 from hari_client import Config
 from hari_client import HARIClient
-
-pytest_plugins = [
-    "tests.upload.fixtures",
-]
+from tests.upload.fixtures import *  # noqa
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+from hari_client import Config
+from hari_client import HARIClient
+
+pytest_plugins = [
+    "tests.upload.fixtures",
+]
+
+
+@pytest.fixture()
+def test_client() -> HARIClient:
+    test_config = Config(
+        hari_username="username",
+        hari_password="password",
+        hari_api_base_url="api_base_url",
+        hari_client_id="client_id",
+        hari_auth_url="auth_url",
+    )
+    return HARIClient(config=test_config)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,14 +1,13 @@
 import pytest
 
-from hari_client import Config
 from hari_client import errors
 from hari_client import HARIClient
 from hari_client import models
 
 
-def test_create_medias_with_missing_file_paths():
+def test_create_medias_with_missing_file_paths(test_client):
     # Arrange
-    hari = HARIClient(config=Config(hari_username="abc", hari_password="123"))
+    client = test_client
     media_create = models.MediaCreate(
         name="my test media",
         back_reference="my test media backref",
@@ -17,12 +16,12 @@ def test_create_medias_with_missing_file_paths():
 
     # Act + Assert
     with pytest.raises(errors.MediaCreateMissingFilePathError):
-        hari.create_medias(dataset_id="1234", medias=[media_create])
+        client.create_medias(dataset_id="1234", medias=[media_create])
 
 
-def test_create_medias_with_different_file_extensions():
+def test_create_medias_with_different_file_extensions(test_client):
     # Arrange
-    hari = HARIClient(config=Config(hari_username="abc", hari_password="123"))
+    client = test_client
     media_create_1 = models.MediaCreate(
         name="my test media 1",
         back_reference="my test media 1 backref",
@@ -38,12 +37,12 @@ def test_create_medias_with_different_file_extensions():
 
     # Act + Assert
     with pytest.raises(errors.UploadingFilesWithDifferentFileExtensionsError):
-        hari.create_medias(dataset_id="1234", medias=[media_create_1, media_create_2])
+        client.create_medias(dataset_id="1234", medias=[media_create_1, media_create_2])
 
 
-def test_create_medias_with_too_many_objects():
+def test_create_medias_with_too_many_objects(test_client):
     # Arrange
-    hari = HARIClient(config=Config(hari_username="abc", hari_password="123"))
+    client = test_client
     media_create = models.MediaCreate(
         name="my test media",
         back_reference="my test media backref",
@@ -53,15 +52,15 @@ def test_create_medias_with_too_many_objects():
 
     # Act + Assert
     with pytest.raises(errors.BulkUploadSizeRangeError):
-        hari.create_medias(
+        client.create_medias(
             dataset_id="1234",
             medias=[media_create for i in range(HARIClient.BULK_UPLOAD_LIMIT + 1)],
         )
 
 
-def test_create_media_objects_with_too_many_objects():
+def test_create_media_objects_with_too_many_objects(test_client):
     # Arrange
-    hari = HARIClient(config=Config(hari_username="abc", hari_password="123"))
+    client = test_client
     media_object_create = models.MediaObjectCreate(
         media_id="1234",
         source=models.DataSource.REFERENCE,
@@ -70,7 +69,7 @@ def test_create_media_objects_with_too_many_objects():
 
     # Act + Assert
     with pytest.raises(errors.BulkUploadSizeRangeError):
-        hari.create_media_objects(
+        client.create_media_objects(
             dataset_id="1234",
             media_objects=[
                 media_object_create for i in range(HARIClient.BULK_UPLOAD_LIMIT + 1)
@@ -78,13 +77,13 @@ def test_create_media_objects_with_too_many_objects():
         )
 
 
-def test_get_presigned_media_upload_url_batch_size_range():
+def test_get_presigned_media_upload_url_batch_size_range(test_client):
     # Arrange
-    hari = HARIClient(config=Config(hari_username="abc", hari_password="123"))
+    client = test_client
 
     # Act + Assert
     with pytest.raises(errors.ParameterNumberRangeError, match="value=0"):
-        hari.get_presigned_media_upload_url(
+        client.get_presigned_media_upload_url(
             dataset_id="1234",
             file_extension=".jpg",
             batch_size=0,
@@ -94,20 +93,20 @@ def test_get_presigned_media_upload_url_batch_size_range():
         errors.ParameterNumberRangeError,
         match=f"value={HARIClient.BULK_UPLOAD_LIMIT + 1}",
     ):
-        hari.get_presigned_media_upload_url(
+        client.get_presigned_media_upload_url(
             dataset_id="1234",
             file_extension=".jpg",
             batch_size=HARIClient.BULK_UPLOAD_LIMIT + 1,
         )
 
 
-def test_get_presigned_visualisation_upload_url_batch_size_range():
+def test_get_presigned_visualisation_upload_url_batch_size_range(test_client):
     # Arrange
-    hari = HARIClient(config=Config(hari_username="abc", hari_password="123"))
+    client = test_client
 
     # Act + Assert
     with pytest.raises(errors.ParameterNumberRangeError, match="value=0"):
-        hari.get_presigned_visualisation_upload_url(
+        client.get_presigned_visualisation_upload_url(
             dataset_id="1234",
             file_extension=".jpg",
             visualisation_config_id="1234",
@@ -118,7 +117,7 @@ def test_get_presigned_visualisation_upload_url_batch_size_range():
         errors.ParameterNumberRangeError,
         match=f"value={HARIClient.BULK_UPLOAD_LIMIT + 1}",
     ):
-        hari.get_presigned_visualisation_upload_url(
+        client.get_presigned_visualisation_upload_url(
             dataset_id="1234",
             file_extension=".jpg",
             visualisation_config_id="1234",
@@ -126,17 +125,17 @@ def test_get_presigned_visualisation_upload_url_batch_size_range():
         )
 
 
-def test_trigger_metadata_rebuild_validation_for_dataset_ids_list():
+def test_trigger_metadata_rebuild_validation_for_dataset_ids_list(test_client):
     # Arrange
-    hari = HARIClient(config=Config(hari_username="abc", hari_password="123"))
+    client = test_client
 
     # Act + Assert
     with pytest.raises(errors.ParameterListLengthError, match="length=0"):
-        hari.trigger_metadata_rebuild_job(
+        client.trigger_metadata_rebuild_job(
             dataset_ids=[],
         )
 
     with pytest.raises(errors.ParameterListLengthError, match="length=11"):
-        hari.trigger_metadata_rebuild_job(
+        client.trigger_metadata_rebuild_job(
             dataset_ids=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
         )

--- a/tests/test_hari_uploader.py
+++ b/tests/test_hari_uploader.py
@@ -446,6 +446,18 @@ def test_hari_uploader_creates_batches_correctly(mocker):
     mocker.patch.object(
         mock_client, "create_attributes", return_value=models.BulkResponse()
     )
+    pedestrian_subset_id = str(uuid.uuid4())
+    wheel_subset_id = str(uuid.uuid4())
+    object_categories = {"pedestrian", "wheel"}
+    object_category_vs_subsets = {
+        "pedestrian": pedestrian_subset_id,
+        "wheel": wheel_subset_id,
+    }
+    mocker.patch.object(
+        mock_client,
+        "create_subset",
+        side_effect=[pedestrian_subset_id, wheel_subset_id],
+    )
 
     # there are multiple batches of medias and media objects, but the bulk_ids for the medias are expected to be continuous
     # as implemented in the create_medias mock above.
@@ -467,7 +479,9 @@ def test_hari_uploader_creates_batches_correctly(mocker):
             running_media_object_bulk_id += 1
 
     mock_uploader = hari_uploader.HARIUploader(
-        client=mock_client, dataset_id=uuid.UUID(int=0)
+        client=mock_client,
+        dataset_id=uuid.UUID(int=0),
+        object_categories=object_categories,
     )
     mocker.patch.object(
         mock_uploader, "_set_bulk_operation_annotatable_id", side_effect=id_setter_mock
@@ -582,12 +596,27 @@ def test_hari_uploader_creates_single_batch_correctly(mocker):
             ]
         ),
     )
+
     mocker.patch.object(
         mock_client, "create_attributes", return_value=models.BulkResponse()
     )
 
+    pedestrian_subset_id = str(uuid.uuid4())
+    wheel_subset_id = str(uuid.uuid4())
+    object_categories = {"pedestrian", "wheel"}
+    object_category_vs_subsets = {
+        "pedestrian": pedestrian_subset_id,
+        "wheel": wheel_subset_id,
+    }
+    mocker.patch.object(
+        mock_client,
+        "create_subset",
+        side_effect=[pedestrian_subset_id, wheel_subset_id],
+    )
     mock_uploader = hari_uploader.HARIUploader(
-        client=mock_client, dataset_id=uuid.UUID(int=0)
+        client=mock_client,
+        dataset_id=uuid.UUID(int=0),
+        object_categories=object_categories,
     )
 
     global running_media_bulk_id
@@ -774,9 +803,22 @@ def test_hari_uploader_sets_bulk_operation_annotatable_id_automatically_on_media
     mocker.patch.object(
         mock_client, "create_media_objects", return_value=models.BulkResponse()
     )
-
+    pedestrian_subset_id = str(uuid.uuid4())
+    wheel_subset_id = str(uuid.uuid4())
+    object_categories = {"pedestrian", "wheel"}
+    object_category_vs_subsets = {
+        "pedestrian": pedestrian_subset_id,
+        "wheel": wheel_subset_id,
+    }
+    mocker.patch.object(
+        mock_client,
+        "create_subset",
+        side_effect=[pedestrian_subset_id, wheel_subset_id],
+    )
     mock_uploader = hari_uploader.HARIUploader(
-        client=mock_client, dataset_id=uuid.UUID(int=0)
+        client=mock_client,
+        dataset_id=uuid.UUID(int=0),
+        object_categories=object_categories,
     )
 
     def id_setter_mock(item: hari_uploader.HARIMedia | hari_uploader.HARIMediaObject):

--- a/tests/test_hari_uploader.py
+++ b/tests/test_hari_uploader.py
@@ -101,7 +101,10 @@ def test_create_object_category_subset(setup_basic_uploader):
     uploader, object_categories_vs_subsets = setup_basic_uploader
 
     # Act
-    uploader._create_object_category_subsets()
+    obj_categories_to_create = [
+        obj_cat for obj_cat in object_categories_vs_subsets.keys()
+    ]
+    uploader._create_object_category_subsets(obj_categories_to_create)
 
     # Assert
     assert uploader._object_category_subsets == object_categories_vs_subsets
@@ -181,8 +184,11 @@ def test_assign_media_objects_to_object_category_subsets(setup_basic_uploader):
     uploader.add_media(media_1)
 
     # Act
-    uploader._create_object_category_subsets()
-    uploader._assign_media_objects_to_object_category_subsets()
+    obj_categories_to_create = [
+        obj_cat for obj_cat in object_categories_vs_subsets.keys()
+    ]
+    uploader._create_object_category_subsets(obj_categories_to_create)
+    uploader._assign_object_category_subsets()
 
     # Assert
     for media in uploader._medias:
@@ -458,6 +464,21 @@ def test_hari_uploader_creates_batches_correctly(mocker):
         "create_subset",
         side_effect=[pedestrian_subset_id, wheel_subset_id],
     )
+    dataset_response = models.DatasetResponse(
+        id=uuid.UUID(int=0),
+        name="my dataset",
+        num_medias=1,
+        num_media_objects=1,
+        num_instances=1,
+        mediatype=models.MediaType.IMAGE,
+    )
+    mocker.patch.object(
+        mock_client,
+        "get_subsets_for_dataset",
+        side_effect=[
+            [dataset_response],
+        ],
+    )
 
     # there are multiple batches of medias and media objects, but the bulk_ids for the medias are expected to be continuous
     # as implemented in the create_medias mock above.
@@ -612,6 +633,21 @@ def test_hari_uploader_creates_single_batch_correctly(mocker):
         mock_client,
         "create_subset",
         side_effect=[pedestrian_subset_id, wheel_subset_id],
+    )
+    dataset_response = models.DatasetResponse(
+        id=uuid.UUID(int=0),
+        name="my dataset",
+        num_medias=1,
+        num_media_objects=1,
+        num_instances=1,
+        mediatype=models.MediaType.IMAGE,
+    )
+    mocker.patch.object(
+        mock_client,
+        "get_subsets_for_dataset",
+        side_effect=[
+            [dataset_response],
+        ],
     )
     mock_uploader = hari_uploader.HARIUploader(
         client=mock_client,
@@ -814,6 +850,21 @@ def test_hari_uploader_sets_bulk_operation_annotatable_id_automatically_on_media
         mock_client,
         "create_subset",
         side_effect=[pedestrian_subset_id, wheel_subset_id],
+    )
+    dataset_response = models.DatasetResponse(
+        id=uuid.UUID(int=0),
+        name="my dataset",
+        num_medias=1,
+        num_media_objects=1,
+        num_instances=1,
+        mediatype=models.MediaType.IMAGE,
+    )
+    mocker.patch.object(
+        mock_client,
+        "get_subsets_for_dataset",
+        side_effect=[
+            [dataset_response],
+        ],
     )
     mock_uploader = hari_uploader.HARIUploader(
         client=mock_client,

--- a/tests/test_hari_uploader.py
+++ b/tests/test_hari_uploader.py
@@ -5,7 +5,6 @@ import pytest
 
 from hari_client import hari_uploader
 from hari_client import models
-from tests.upload import fixtures
 
 
 def test_add_media(mock_uploader_for_object_category_validation):
@@ -494,7 +493,9 @@ def test_hari_uploader_creates_batches_correctly(mock_uploader_for_batching):
     assert uploader._attribute_cnt == 6600
 
 
-def test_hari_uploader_creates_single_batch_correctly(mocker, test_client):
+def test_hari_uploader_creates_single_batch_correctly(
+    create_configurable_mock_uploader_successful_single_batch,
+):
     # Arrange
     (
         uploader,
@@ -503,9 +504,7 @@ def test_hari_uploader_creates_single_batch_correctly(mocker, test_client):
         media_object_spy,
         attribute_spy,
         subset_create_spy,
-    ) = fixtures.create_configurable_mock_uploader_successfull_single_batch(
-        mocker,
-        test_client,
+    ) = create_configurable_mock_uploader_successful_single_batch(
         dataset_id=uuid.UUID(int=0),
         medias_cnt=5,
         media_objects_cnt=10,
@@ -723,7 +722,7 @@ def test_hari_uploader_upload_without_specified_object_categories(mock_client):
 
 
 def test_hari_uploader_upload_with_known_specified_object_categories(
-    mocker, test_client
+    create_configurable_mock_uploader_successful_single_batch,
 ):
     # Arrange
     (
@@ -733,9 +732,7 @@ def test_hari_uploader_upload_with_known_specified_object_categories(
         _,
         _,
         subset_create_spy,
-    ) = fixtures.create_configurable_mock_uploader_successfull_single_batch(
-        mocker,
-        test_client,
+    ) = create_configurable_mock_uploader_successful_single_batch(
         dataset_id=uuid.UUID(int=0),
         medias_cnt=1,
         media_objects_cnt=3,
@@ -773,7 +770,7 @@ def test_hari_uploader_upload_with_known_specified_object_categories(
 
 
 def test_hari_uploader_upload_with_unknown_specified_object_categories(
-    mocker, test_client
+    create_configurable_mock_uploader_successful_single_batch,
 ):
     # Arrange
     (
@@ -783,9 +780,7 @@ def test_hari_uploader_upload_with_unknown_specified_object_categories(
         _,
         _,
         subset_create_spy,
-    ) = fixtures.create_configurable_mock_uploader_successfull_single_batch(
-        mocker,
-        test_client,
+    ) = create_configurable_mock_uploader_successful_single_batch(
         dataset_id=uuid.UUID(int=0),
         medias_cnt=1,
         media_objects_cnt=3,
@@ -829,7 +824,7 @@ def test_hari_uploader_upload_with_unknown_specified_object_categories(
 
 
 def test_hari_uploader_upload_with_already_existing_backend_category_subsets(
-    mocker, test_client
+    create_configurable_mock_uploader_successful_single_batch,
 ):
     # Arrange
     (
@@ -839,9 +834,7 @@ def test_hari_uploader_upload_with_already_existing_backend_category_subsets(
         _,
         _,
         subset_create_spy,
-    ) = fixtures.create_configurable_mock_uploader_successfull_single_batch(
-        mocker,
-        test_client,
+    ) = create_configurable_mock_uploader_successful_single_batch(
         dataset_id=uuid.UUID(int=0),
         medias_cnt=1,
         media_objects_cnt=3,

--- a/tests/test_hari_uploader.py
+++ b/tests/test_hari_uploader.py
@@ -1,11 +1,8 @@
 import collections
-import uuid
 
 import pytest
 
-from hari_client import Config
 from hari_client import hari_uploader
-from hari_client import HARIClient
 from hari_client import models
 
 
@@ -20,226 +17,267 @@ from hari_client import models
 # - starting an upload with non-eixstent object_categories on server - fail it, continue the upload
 
 
-class TestHariUploader:
-    """
-    Tests for the HARIUploader class.
-    How to use:
-    - check if an existing fixture can be used for your test
-        - if not, create a new fixture with a HariClient to prepare the test data
-    """
+def test_add_media(mock_uploader_for_object_category_validation):
+    # Arrange
+    (
+        uploader,
+        object_categories_vs_subsets,
+    ) = mock_uploader_for_object_category_validation
+    assert len(uploader._medias) == 0
+    assert uploader._attribute_cnt == 0
 
-    @pytest.fixture()
-    def test_client(self) -> None:
-        self.test_config = Config(
-            hari_username="username",
-            hari_password="password",
-            hari_api_base_url="api_base_url",
-            hari_client_id="client_id",
-            hari_auth_url="auth_url",
-        )
-        self.test_client = HARIClient(config=self.test_config)
-
-    # TODO: more test setups, better names
-    @pytest.fixture(autouse=True)
-    def mock_client_(
-        self, test_client, mocker
-    ) -> tuple[hari_uploader.HARIUploader, dict[str, str]]:
-        """Sets up a basic uplader using object_categories
-        returns
-            self.uploader: HARIUploader instance
-            object_category_vs_subsets: dict[str, str] mapping object category names to their subset ids
-        """
-
-        pedestrian_subset_id = str(uuid.uuid4())
-        wheel_subset_id = str(uuid.uuid4())
-        object_categories = {"pedestrian", "wheel"}
-        self.mock_client = HARIClient(config=self.test_config)
-        mocker.patch.object(
-            self.mock_client,
-            "create_subset",
-            side_effect=[pedestrian_subset_id, wheel_subset_id],
-        )
-
-        self.uploader = hari_uploader.HARIUploader(
-            client=self.mock_client,
-            dataset_id=uuid.UUID(int=0),
-            object_categories_to_validate=object_categories,
-        )
-        assert self.uploader.object_categories_to_validate == {
-            "pedestrian",
-            "wheel",
-        }
-        self.object_categories_vs_subsets = {
-            "pedestrian": pedestrian_subset_id,
-            "wheel": wheel_subset_id,
-        }
-        assert self.uploader._object_category_subsets == {}
-
-    def test_add_media(self):
-        # Arrange
-
-        assert len(self.uploader._medias) == 0
-        assert self.uploader._attribute_cnt == 0
-
-        # Act
-        self.uploader.add_media(
-            hari_uploader.HARIMedia(
-                name="my image",
-                media_type=models.MediaType.IMAGE,
-                back_reference="img",
-                attributes=[
-                    hari_uploader.HARIAttribute(
-                        id="attr_1",
-                        name="my attribute 1",
-                        attribute_type=models.AttributeType.Categorical,
-                        value="value 1",
-                        attribute_group=models.AttributeGroup.InitialAttribute,
-                    )
-                ],
-            )
-        )
-
-        # Assert
-        assert len(self.uploader._medias) == 1
-        assert self.uploader._attribute_cnt == 1
-
-        # Act
-        # add another media without attributes
-        self.uploader.add_media(
-            hari_uploader.HARIMedia(
-                name="my image",
-                media_type=models.MediaType.IMAGE,
-                back_reference="img",
-            )
-        )
-        # Assert
-        assert len(self.uploader._medias) == 2
-        assert self.uploader._attribute_cnt == 1
-
-    def test_create_object_category_subset(self):
-        # Act
-        obj_categories_to_create = [
-            obj_cat for obj_cat in self.object_categories_vs_subsets.keys()
-        ]
-        self.uploader._create_object_category_subsets(obj_categories_to_create)
-
-        # Assert
-        assert (
-            self.uploader._object_category_subsets == self.object_categories_vs_subsets
-        )
-
-    def test_validate_media_objects_object_category_subsets_consistency(
-        self,
-    ):
-        # Arrange
-        media_1 = hari_uploader.HARIMedia(
-            name="my image 1",
+    # Act
+    uploader.add_media(
+        hari_uploader.HARIMedia(
+            name="my image",
             media_type=models.MediaType.IMAGE,
-            back_reference="img_1",
-            object_category_subset_name="pedestrian",
+            back_reference="img",
+            attributes=[
+                hari_uploader.HARIAttribute(
+                    id="attr_1",
+                    name="my attribute 1",
+                    attribute_type=models.AttributeType.Categorical,
+                    value="value 1",
+                    attribute_group=models.AttributeGroup.InitialAttribute,
+                )
+            ],
         )
-        media_object_1 = hari_uploader.HARIMediaObject(
+    )
+
+    # Assert
+    assert len(uploader._medias) == 1
+    assert uploader._attribute_cnt == 1
+
+    # Act
+    # add another media without attributes
+    uploader.add_media(
+        hari_uploader.HARIMedia(
+            name="my image",
+            media_type=models.MediaType.IMAGE,
+            back_reference="img",
+        )
+    )
+    # Assert
+    assert len(uploader._medias) == 2
+    assert uploader._attribute_cnt == 1
+
+
+def test_create_object_category_subset(mock_uploader_for_object_category_validation):
+    (
+        uploader,
+        object_categories_vs_subsets,
+    ) = mock_uploader_for_object_category_validation
+
+    # Act
+    obj_categories_to_create = [
+        obj_cat for obj_cat in object_categories_vs_subsets.keys()
+    ]
+    uploader._create_object_category_subsets(obj_categories_to_create)
+
+    # Assert
+    assert uploader._object_category_subsets == object_categories_vs_subsets
+
+
+def test_validate_media_objects_object_category_subsets_consistency(
+    mock_uploader_for_object_category_validation,
+):
+    # Arrange
+    (
+        uploader,
+        object_categories_vs_subsets,
+    ) = mock_uploader_for_object_category_validation
+
+    media_1 = hari_uploader.HARIMedia(
+        name="my image 1",
+        media_type=models.MediaType.IMAGE,
+        back_reference="img_1",
+        object_category_subset_name="pedestrian",
+    )
+    media_object_1 = hari_uploader.HARIMediaObject(
+        source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
+    )
+    media_object_1.set_object_category_subset_name("pedestrian")
+    media_1.add_media_object(media_object_1)
+    uploader.add_media(media_1)
+    # Act
+    errors = uploader._validate_media_objects_object_category_subsets_consistency()
+
+    # Assert
+    assert len(errors) == 0
+
+    # Arrange
+    media_object_2 = hari_uploader.HARIMediaObject(
+        source=models.DataSource.REFERENCE, back_reference="img_1_obj_2"
+    )
+    media_object_2.set_object_category_subset_name("some_non-existent-subset_name")
+    media_1.add_media_object(media_object_2)
+
+    # Act
+
+    # Assert
+    errors = uploader._validate_media_objects_object_category_subsets_consistency()
+    assert len(errors) == 1
+    assert (
+        type(errors[0])
+        == hari_uploader.HARIMediaObjectUnknownObjectCategorySubsetNameError
+    )
+
+
+def test_assign_media_objects_to_object_category_subsets(
+    mock_uploader_for_object_category_validation,
+):
+    # Arrange
+    (
+        uploader,
+        object_categories_vs_subsets,
+    ) = mock_uploader_for_object_category_validation
+
+    obj_cat_vs_subs_iter = iter(object_categories_vs_subsets.items())
+    object_category_1, subset_1 = next(obj_cat_vs_subs_iter)
+    object_category_2, subset_2 = next(obj_cat_vs_subs_iter)
+
+    media_1 = hari_uploader.HARIMedia(
+        name="my image 1",
+        media_type=models.MediaType.IMAGE,
+        back_reference="img_1",
+        object_category_subset_name="pedestrian",
+    )
+    media_object_1 = hari_uploader.HARIMediaObject(
+        source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
+    )
+    media_object_1.set_object_category_subset_name("pedestrian")
+    media_1.add_media_object(media_object_1)
+    media_object_2 = hari_uploader.HARIMediaObject(
+        source=models.DataSource.REFERENCE, back_reference="img_1_obj_2"
+    )
+    media_object_2.set_object_category_subset_name("wheel")
+    media_1.add_media_object(media_object_2)
+    uploader.add_media(media_1)
+
+    # Act
+    obj_categories_to_create = [
+        obj_cat for obj_cat in object_categories_vs_subsets.keys()
+    ]
+    uploader._create_object_category_subsets(obj_categories_to_create)
+    uploader._assign_object_category_subsets()
+
+    # Assert
+    for media in uploader._medias:
+        for media_object in media.media_objects:
+            if media_object.object_category_subset_name == object_category_1:
+                assert media_object.subset_ids == [subset_1]
+            elif media_object.object_category_subset_name == object_category_2:
+                assert media_object.subset_ids == [subset_2]
+        assert collections.Counter(media.subset_ids) == collections.Counter(
+            [subset_1, subset_2]
+        )
+
+
+def test_update_hari_media_object_media_ids(
+    mock_uploader_for_object_category_validation,
+):
+    # Arrange
+    (
+        uploader,
+        object_categories_vs_subsets,
+    ) = mock_uploader_for_object_category_validation
+
+    media_1 = hari_uploader.HARIMedia(
+        name="my image 1",
+        media_type=models.MediaType.IMAGE,
+        back_reference="img_1",
+    )
+    media_1.bulk_operation_annotatable_id = "bulk_id_1"
+    media_1.add_media_object(
+        hari_uploader.HARIMediaObject(
             source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
         )
-        media_object_1.set_object_category_subset_name("pedestrian")
-        media_1.add_media_object(media_object_1)
-        self.uploader.add_media(media_1)
-        # Act
-        errors = (
-            self.uploader._validate_media_objects_object_category_subsets_consistency()
+    )
+    uploader.add_media(media_1)
+    media_2 = hari_uploader.HARIMedia(
+        name="my image 2",
+        media_type=models.MediaType.IMAGE,
+        back_reference="img_2",
+    )
+    media_2.bulk_operation_annotatable_id = "bulk_id_2"
+    media_2.add_media_object(
+        hari_uploader.HARIMediaObject(
+            source=models.DataSource.REFERENCE, back_reference="img_2_obj_1"
         )
-
-        # Assert
-        assert len(errors) == 0
-
-        # Arrange
-        media_object_2 = hari_uploader.HARIMediaObject(
-            source=models.DataSource.REFERENCE, back_reference="img_1_obj_2"
-        )
-        media_object_2.set_object_category_subset_name("some_non-existent-subset_name")
-        media_1.add_media_object(media_object_2)
-
-        # Act
-
-        # Assert
-        errors = (
-            self.uploader._validate_media_objects_object_category_subsets_consistency()
-        )
-        assert len(errors) == 1
-        assert (
-            type(errors[0])
-            == hari_uploader.HARIMediaObjectUnknownObjectCategorySubsetNameError
-        )
-
-    def test_assign_media_objects_to_object_category_subsets(self):
-        # Arrange
-        obj_cat_vs_subs_iter = iter(self.object_categories_vs_subsets.items())
-        object_category_1, subset_1 = next(obj_cat_vs_subs_iter)
-        object_category_2, subset_2 = next(obj_cat_vs_subs_iter)
-
-        media_1 = hari_uploader.HARIMedia(
-            name="my image 1",
-            media_type=models.MediaType.IMAGE,
-            back_reference="img_1",
-            object_category_subset_name="pedestrian",
-        )
-        media_object_1 = hari_uploader.HARIMediaObject(
-            source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
-        )
-        media_object_1.set_object_category_subset_name("pedestrian")
-        media_1.add_media_object(media_object_1)
-        media_object_2 = hari_uploader.HARIMediaObject(
-            source=models.DataSource.REFERENCE, back_reference="img_1_obj_2"
-        )
-        media_object_2.set_object_category_subset_name("wheel")
-        media_1.add_media_object(media_object_2)
-        self.uploader.add_media(media_1)
-
-        # Act
-        obj_categories_to_create = [
-            obj_cat for obj_cat in self.object_categories_vs_subsets.keys()
+    )
+    uploader.add_media(media_2)
+    media_upload_bulk_response = models.BulkResponse(
+        results=[
+            models.AnnotatableCreateResponse(
+                item_id="new_media_id_1",
+                back_reference="img_1",
+                bulk_operation_annotatable_id="bulk_id_1",
+                status=models.ResponseStatesEnum.SUCCESS,
+            ),
+            models.AnnotatableCreateResponse(
+                item_id="new_media_id_2",
+                back_reference="img_2",
+                bulk_operation_annotatable_id="bulk_id_2",
+                status=models.ResponseStatesEnum.SUCCESS,
+            ),
         ]
-        self.uploader._create_object_category_subsets(obj_categories_to_create)
-        self.uploader._assign_object_category_subsets()
+    )
 
-        # Assert
-        for media in self.uploader._medias:
-            for media_object in media.media_objects:
-                if media_object.object_category_subset_name == object_category_1:
-                    assert media_object.subset_ids == [subset_1]
-                elif media_object.object_category_subset_name == object_category_2:
-                    assert media_object.subset_ids == [subset_2]
-            assert collections.Counter(media.subset_ids) == collections.Counter(
-                [subset_1, subset_2]
-            )
+    # Act
+    uploader._update_hari_media_object_media_ids(
+        medias_to_upload=[media_1, media_2],
+        media_upload_bulk_response=media_upload_bulk_response,
+    )
 
-    def test_update_hari_media_object_media_ids(self):
-        # Arrange
-        media_1 = hari_uploader.HARIMedia(
-            name="my image 1",
-            media_type=models.MediaType.IMAGE,
-            back_reference="img_1",
+    # Assert
+    assert uploader._medias[0].media_objects[0].media_id == "new_media_id_1"
+    assert uploader._medias[1].media_objects[0].media_id == "new_media_id_2"
+
+
+def test_update_hari_attribute_media_ids(mock_uploader_for_object_category_validation):
+    # Arrange
+    (
+        uploader,
+        object_categories_vs_subsets,
+    ) = mock_uploader_for_object_category_validation
+
+    media_1 = hari_uploader.HARIMedia(
+        name="my image 1",
+        media_type=models.MediaType.IMAGE,
+        back_reference="img_1",
+    )
+    media_1.bulk_operation_annotatable_id = "bulk_id_1"
+    media_1.add_attribute(
+        hari_uploader.HARIAttribute(
+            id="attr_1",
+            name="my attribute 1",
+            attribute_type=models.AttributeType.Categorical,
+            value="value 1",
+            attribute_group=models.AttributeGroup.InitialAttribute,
         )
-        media_1.bulk_operation_annotatable_id = "bulk_id_1"
-        media_1.add_media_object(
-            hari_uploader.HARIMediaObject(
-                source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
-            )
+    )
+    uploader.add_media(media_1)
+    media_2 = hari_uploader.HARIMedia(
+        name="my image 2",
+        media_type=models.MediaType.IMAGE,
+        back_reference="img_2",
+    )
+    media_2.bulk_operation_annotatable_id = "bulk_id_2"
+    media_2.add_attribute(
+        hari_uploader.HARIAttribute(
+            id="attr_1",
+            name="my attribute 2",
+            attribute_type=models.AttributeType.Categorical,
+            value="value 2",
+            attribute_group=models.AttributeGroup.InitialAttribute,
         )
-        self.uploader.add_media(media_1)
-        media_2 = hari_uploader.HARIMedia(
-            name="my image 2",
-            media_type=models.MediaType.IMAGE,
-            back_reference="img_2",
-        )
-        media_2.bulk_operation_annotatable_id = "bulk_id_2"
-        media_2.add_media_object(
-            hari_uploader.HARIMediaObject(
-                source=models.DataSource.REFERENCE, back_reference="img_2_obj_1"
-            )
-        )
-        self.uploader.add_media(media_2)
-        media_upload_bulk_response = models.BulkResponse(
+    )
+    uploader.add_media(media_2)
+
+    # Act
+    uploader._update_hari_attribute_media_ids(
+        medias_to_upload=[media_1, media_2],
+        media_upload_bulk_response=models.BulkResponse(
             results=[
                 models.AnnotatableCreateResponse(
                     item_id="new_media_id_1",
@@ -254,769 +292,449 @@ class TestHariUploader:
                     status=models.ResponseStatesEnum.SUCCESS,
                 ),
             ]
-        )
+        ),
+    )
 
-        # Act
-        self.uploader._update_hari_media_object_media_ids(
-            medias_to_upload=[media_1, media_2],
-            media_upload_bulk_response=media_upload_bulk_response,
-        )
+    # Assert
+    assert media_1.attributes[0].annotatable_id == "new_media_id_1"
+    assert media_1.attributes[0].annotatable_type == models.DataBaseObjectType.MEDIA
+    assert media_2.attributes[0].annotatable_id == "new_media_id_2"
+    assert media_2.attributes[0].annotatable_type == models.DataBaseObjectType.MEDIA
+    assert uploader._attribute_cnt == 2
 
-        # Assert
-        assert self.uploader._medias[0].media_objects[0].media_id == "new_media_id_1"
-        assert self.uploader._medias[1].media_objects[0].media_id == "new_media_id_2"
 
-    def test_update_hari_attribute_media_ids(self):
-        # Arrange
-        media_1 = hari_uploader.HARIMedia(
-            name="my image 1",
-            media_type=models.MediaType.IMAGE,
-            back_reference="img_1",
-        )
-        media_1.bulk_operation_annotatable_id = "bulk_id_1"
-        media_1.add_attribute(
-            hari_uploader.HARIAttribute(
-                id="attr_1",
-                name="my attribute 1",
-                attribute_type=models.AttributeType.Categorical,
-                value="value 1",
-                attribute_group=models.AttributeGroup.InitialAttribute,
-            )
-        )
-        self.uploader.add_media(media_1)
-        media_2 = hari_uploader.HARIMedia(
-            name="my image 2",
-            media_type=models.MediaType.IMAGE,
-            back_reference="img_2",
-        )
-        media_2.bulk_operation_annotatable_id = "bulk_id_2"
-        media_2.add_attribute(
-            hari_uploader.HARIAttribute(
-                id="attr_1",
-                name="my attribute 2",
-                attribute_type=models.AttributeType.Categorical,
-                value="value 2",
-                attribute_group=models.AttributeGroup.InitialAttribute,
-            )
-        )
-        self.uploader.add_media(media_2)
+def test_update_hari_attribute_media_object_ids(
+    mock_uploader_for_object_category_validation,
+):
+    # Arrange
+    (
+        uploader,
+        object_categories_vs_subsets,
+    ) = mock_uploader_for_object_category_validation
 
-        # Act
-        self.uploader._update_hari_attribute_media_ids(
-            medias_to_upload=[media_1, media_2],
-            media_upload_bulk_response=models.BulkResponse(
-                results=[
-                    models.AnnotatableCreateResponse(
-                        item_id="new_media_id_1",
-                        back_reference="img_1",
-                        bulk_operation_annotatable_id="bulk_id_1",
-                        status=models.ResponseStatesEnum.SUCCESS,
-                    ),
-                    models.AnnotatableCreateResponse(
-                        item_id="new_media_id_2",
-                        back_reference="img_2",
-                        bulk_operation_annotatable_id="bulk_id_2",
-                        status=models.ResponseStatesEnum.SUCCESS,
-                    ),
-                ]
-            ),
-        )
+    media_1 = hari_uploader.HARIMedia(
+        name="my image 1",
+        media_type=models.MediaType.IMAGE,
+        back_reference="img_1",
+    )
+    media_object_1 = hari_uploader.HARIMediaObject(
+        source=models.DataSource.REFERENCE,
+        back_reference="img_1_obj_1",
+        reference_data=models.BBox2DCenterPoint(
+            type=models.BBox2DType.BBOX2D_CENTER_POINT,
+            x=1400.0,
+            y=1806.0,
+            width=344.0,
+            height=732.0,
+        ),
+    )
+    media_object_1.bulk_operation_annotatable_id = "bulk_id_1"
+    attribute_object_1 = hari_uploader.HARIAttribute(
+        id="attr_1",
+        name="Is human?",
+        attribute_type=models.AttributeType.Categorical,
+        value="yes",
+        attribute_group=models.AttributeGroup.InitialAttribute,
+    )
+    media_object_1.add_attribute(attribute_object_1)
+    media_1.add_media_object(media_object_1)
 
-        # Assert
-        assert media_1.attributes[0].annotatable_id == "new_media_id_1"
-        assert media_1.attributes[0].annotatable_type == models.DataBaseObjectType.MEDIA
-        assert media_2.attributes[0].annotatable_id == "new_media_id_2"
-        assert media_2.attributes[0].annotatable_type == models.DataBaseObjectType.MEDIA
-        assert self.uploader._attribute_cnt == 2
+    media_2 = hari_uploader.HARIMedia(
+        name="my image 2",
+        media_type=models.MediaType.IMAGE,
+        back_reference="img_2",
+    )
+    media_object_2 = hari_uploader.HARIMediaObject(
+        source=models.DataSource.REFERENCE,
+        back_reference="img_2_obj_1",
+        reference_data=models.BBox2DCenterPoint(
+            type=models.BBox2DType.BBOX2D_CENTER_POINT,
+            x=1400.0,
+            y=1806.0,
+            width=344.0,
+            height=732.0,
+        ),
+    )
+    media_object_2.bulk_operation_annotatable_id = "bulk_id_2"
+    attribute_object_2 = hari_uploader.HARIAttribute(
+        id="attr_1",
+        name="Is human?",
+        attribute_type=models.AttributeType.Categorical,
+        value="yes",
+        attribute_group=models.AttributeGroup.InitialAttribute,
+    )
+    media_object_2.add_attribute(attribute_object_2)
+    media_2.add_media_object(media_object_2)
 
-    def test_update_hari_attribute_media_object_ids(self):
-        # Arrange
-        media_1 = hari_uploader.HARIMedia(
-            name="my image 1",
-            media_type=models.MediaType.IMAGE,
-            back_reference="img_1",
-        )
-        media_object_1 = hari_uploader.HARIMediaObject(
-            source=models.DataSource.REFERENCE,
-            back_reference="img_1_obj_1",
-            reference_data=models.BBox2DCenterPoint(
-                type=models.BBox2DType.BBOX2D_CENTER_POINT,
-                x=1400.0,
-                y=1806.0,
-                width=344.0,
-                height=732.0,
-            ),
-        )
-        media_object_1.bulk_operation_annotatable_id = "bulk_id_1"
-        attribute_object_1 = hari_uploader.HARIAttribute(
-            id="attr_1",
-            name="Is human?",
-            attribute_type=models.AttributeType.Categorical,
-            value="yes",
-            attribute_group=models.AttributeGroup.InitialAttribute,
-        )
-        media_object_1.add_attribute(attribute_object_1)
-        media_1.add_media_object(media_object_1)
+    # Act
+    uploader._update_hari_attribute_media_object_ids(
+        media_objects_to_upload=[media_object_1, media_object_2],
+        media_object_upload_bulk_response=models.BulkResponse(
+            results=[
+                models.AnnotatableCreateResponse(
+                    item_id="new_media_object_id_1",
+                    back_reference="img_1_obj_1",
+                    bulk_operation_annotatable_id="bulk_id_1",
+                    status=models.ResponseStatesEnum.SUCCESS,
+                ),
+                models.AnnotatableCreateResponse(
+                    item_id="new_media_object_id_2",
+                    back_reference="img_2_obj_1",
+                    bulk_operation_annotatable_id="bulk_id_2",
+                    status=models.ResponseStatesEnum.SUCCESS,
+                ),
+            ]
+        ),
+    )
 
-        media_2 = hari_uploader.HARIMedia(
-            name="my image 2",
-            media_type=models.MediaType.IMAGE,
-            back_reference="img_2",
-        )
-        media_object_2 = hari_uploader.HARIMediaObject(
-            source=models.DataSource.REFERENCE,
-            back_reference="img_2_obj_1",
-            reference_data=models.BBox2DCenterPoint(
-                type=models.BBox2DType.BBOX2D_CENTER_POINT,
-                x=1400.0,
-                y=1806.0,
-                width=344.0,
-                height=732.0,
-            ),
-        )
-        media_object_2.bulk_operation_annotatable_id = "bulk_id_2"
-        attribute_object_2 = hari_uploader.HARIAttribute(
-            id="attr_1",
-            name="Is human?",
-            attribute_type=models.AttributeType.Categorical,
-            value="yes",
-            attribute_group=models.AttributeGroup.InitialAttribute,
-        )
-        media_object_2.add_attribute(attribute_object_2)
-        media_2.add_media_object(media_object_2)
+    # Assert
+    assert media_object_1.attributes[0].annotatable_id == "new_media_object_id_1"
+    assert (
+        media_object_1.attributes[0].annotatable_type
+        == models.DataBaseObjectType.MEDIAOBJECT
+    )
+    assert media_object_2.attributes[0].annotatable_id == "new_media_object_id_2"
+    assert (
+        media_object_2.attributes[0].annotatable_type
+        == models.DataBaseObjectType.MEDIAOBJECT
+    )
 
-        # Act
-        self.uploader._update_hari_attribute_media_object_ids(
-            media_objects_to_upload=[media_object_1, media_object_2],
-            media_object_upload_bulk_response=models.BulkResponse(
-                results=[
-                    models.AnnotatableCreateResponse(
-                        item_id="new_media_object_id_1",
-                        back_reference="img_1_obj_1",
-                        bulk_operation_annotatable_id="bulk_id_1",
-                        status=models.ResponseStatesEnum.SUCCESS,
-                    ),
-                    models.AnnotatableCreateResponse(
-                        item_id="new_media_object_id_2",
-                        back_reference="img_2_obj_1",
-                        bulk_operation_annotatable_id="bulk_id_2",
-                        status=models.ResponseStatesEnum.SUCCESS,
-                    ),
-                ]
-            ),
-        )
 
-        # Assert
-        assert media_object_1.attributes[0].annotatable_id == "new_media_object_id_1"
-        assert (
-            media_object_1.attributes[0].annotatable_type
-            == models.DataBaseObjectType.MEDIAOBJECT
-        )
-        assert media_object_2.attributes[0].annotatable_id == "new_media_object_id_2"
-        assert (
-            media_object_2.attributes[0].annotatable_type
-            == models.DataBaseObjectType.MEDIAOBJECT
-        )
+def test_hari_uploader_creates_batches_correctly(mock_uploader_for_batching):
+    # Arrange
+    uploader, media_spy, media_object_spy, attribute_spy = mock_uploader_for_batching
 
-    def test_hari_uploader_creates_batches_correctly(self, mocker):
-        # Arrange
-        # setup self.mock_client and mock_uploader that allow for testing the full upload method
-        mocker.patch.object(
-            self.mock_client,
-            "create_medias",
-            return_value=models.BulkResponse(
-                results=[
-                    models.AnnotatableCreateResponse(
-                        status=models.ResponseStatesEnum.SUCCESS,
-                        bulk_operation_annotatable_id=f"bulk_id_{i}",
-                    )
-                    for i in range(1100)
-                ]
-            ),
-        )
-        mocker.patch.object(
-            self.mock_client,
-            "create_media_objects",
-            return_value=models.BulkResponse(
-                results=[
-                    models.AnnotatableCreateResponse(
-                        status=models.ResponseStatesEnum.SUCCESS,
-                        bulk_operation_annotatable_id=f"bulk_id_{i}",
-                    )
-                    for i in range(2200)
-                ]
-            ),
-        )
-        mocker.patch.object(
-            self.mock_client, "create_attributes", return_value=models.BulkResponse()
-        )
-        pedestrian_subset_id = str(uuid.uuid4())
-        wheel_subset_id = str(uuid.uuid4())
-        object_categories = {"pedestrian", "wheel"}
-        object_category_vs_subsets = {
-            "pedestrian": pedestrian_subset_id,
-            "wheel": wheel_subset_id,
-        }
-        mocker.patch.object(
-            self.mock_client,
-            "create_subset",
-            side_effect=[pedestrian_subset_id, wheel_subset_id],
-        )
-        dataset_response = models.DatasetResponse(
-            id=uuid.UUID(int=0),
-            name="my dataset",
-            num_medias=1,
-            num_media_objects=1,
-            num_instances=1,
-            mediatype=models.MediaType.IMAGE,
-        )
-        mocker.patch.object(
-            self.mock_client,
-            "get_subsets_for_dataset",
-            side_effect=[
-                [dataset_response],
-            ],
-        )
-
-        # there are multiple batches of medias and media objects, but the bulk_ids for the medias are expected to be continuous
-        # as implemented in the create_medias mock above.
-        global running_media_bulk_id
-        running_media_bulk_id = 0
-        global running_media_object_bulk_id
-        running_media_object_bulk_id = 0
-
-        def id_setter_mock(
-            item: hari_uploader.HARIMedia | hari_uploader.HARIMediaObject,
-        ):
-            global running_media_bulk_id
-            global running_media_object_bulk_id
-            if isinstance(item, hari_uploader.HARIMedia):
-                item.bulk_operation_annotatable_id = f"bulk_id_{running_media_bulk_id}"
-                running_media_bulk_id += 1
-            elif isinstance(item, hari_uploader.HARIMediaObject):
-                item.bulk_operation_annotatable_id = (
-                    f"bulk_id_{running_media_object_bulk_id}"
-                )
-                running_media_object_bulk_id += 1
-
-        mock_uploader = hari_uploader.HARIUploader(
-            client=self.mock_client,
-            dataset_id=uuid.UUID(int=0),
-            object_categories_to_validate=object_categories,
-        )
-        mocker.patch.object(
-            mock_uploader,
-            "_set_bulk_operation_annotatable_id",
-            side_effect=id_setter_mock,
-        )
-        media_spy = mocker.spy(mock_uploader, "_upload_media_batch")
-        media_object_spy = mocker.spy(mock_uploader, "_upload_media_object_batch")
-        attribute_spy = mocker.spy(mock_uploader, "_upload_attribute_batch")
-
-        # 1100 medias --> 3 batches
-        # 2200 media_objects --> 5 batches
-        # 6600 attributes --> 14 batches
-        for i in range(1100):
-            media = hari_uploader.HARIMedia(
-                name=f"my image {i}",
-                media_type=models.MediaType.IMAGE,
-                back_reference=f"img_{i}",
-            )
-            for k in range(2):
-                media_object = hari_uploader.HARIMediaObject(
-                    source=models.DataSource.REFERENCE,
-                    back_reference=f"img_{i}_obj_{k}",
-                )
-                media.add_media_object(media_object)
-                media.add_attribute(
-                    hari_uploader.HARIAttribute(
-                        id=f"attr_{i}_{k}",
-                        name=f"attr_{i}_{k}",
-                        attribute_type=models.AttributeType.Categorical,
-                        value=f"value_{i}_{k}",
-                        attribute_group=models.AttributeGroup.InitialAttribute,
-                    )
-                )
-                for l in range(2):
-                    media_object.add_attribute(
-                        hari_uploader.HARIAttribute(
-                            id=f"attr_{i}_{k}_{l}",
-                            name=f"attr_{i}_{k}_{l}",
-                            attribute_type=models.AttributeType.Categorical,
-                            value=f"value_{i}_{k}_{l}",
-                            attribute_group=models.AttributeGroup.InitialAttribute,
-                        )
-                    )
-            mock_uploader.add_media(media)
-
-        # Act
-        mock_uploader.upload()
-
-        # Assert
-        # check every batch upload method's call
-        assert media_spy.call_count == 3
-        media_calls = media_spy.call_args_list
-        assert len(media_calls[0].kwargs["medias_to_upload"]) == 500
-        assert len(media_calls[1].kwargs["medias_to_upload"]) == 500
-        assert len(media_calls[2].kwargs["medias_to_upload"]) == 100
-        assert len(mock_uploader._medias) == 1100
-
-        assert media_object_spy.call_count == 5
-        media_object_calls = media_object_spy.call_args_list
-        assert len(media_object_calls[0].kwargs["media_objects_to_upload"]) == 500
-        assert len(media_object_calls[1].kwargs["media_objects_to_upload"]) == 500
-        assert len(media_object_calls[2].kwargs["media_objects_to_upload"]) == 500
-        assert len(media_object_calls[3].kwargs["media_objects_to_upload"]) == 500
-        assert len(media_object_calls[4].kwargs["media_objects_to_upload"]) == 200
-        assert mock_uploader._media_object_cnt == 2200
-
-        assert attribute_spy.call_count == 14
-        attribute_calls = attribute_spy.call_args_list
-        assert len(attribute_calls[0].kwargs["attributes_to_upload"]) == 500
-        assert len(attribute_calls[1].kwargs["attributes_to_upload"]) == 500
-        assert len(attribute_calls[2].kwargs["attributes_to_upload"]) == 500
-        assert len(attribute_calls[3].kwargs["attributes_to_upload"]) == 500
-        assert len(attribute_calls[4].kwargs["attributes_to_upload"]) == 500
-        assert len(attribute_calls[5].kwargs["attributes_to_upload"]) == 500
-        assert len(attribute_calls[6].kwargs["attributes_to_upload"]) == 500
-        assert len(attribute_calls[7].kwargs["attributes_to_upload"]) == 500
-        assert len(attribute_calls[8].kwargs["attributes_to_upload"]) == 500
-        assert len(attribute_calls[9].kwargs["attributes_to_upload"]) == 500
-        assert len(attribute_calls[10].kwargs["attributes_to_upload"]) == 500
-        assert len(attribute_calls[11].kwargs["attributes_to_upload"]) == 500
-        assert len(attribute_calls[12].kwargs["attributes_to_upload"]) == 500
-        assert len(attribute_calls[13].kwargs["attributes_to_upload"]) == 100
-        assert mock_uploader._attribute_cnt == 6600
-
-    def test_hari_uploader_creates_single_batch_correctly(self, mocker):
-        # Arrange
-        # setup self.mock_client and mock_uploader that allow for testing the full upload method
-        mocker.patch.object(
-            self.mock_client,
-            "create_medias",
-            return_value=models.BulkResponse(
-                results=[
-                    models.AnnotatableCreateResponse(
-                        status=models.ResponseStatesEnum.SUCCESS,
-                        bulk_operation_annotatable_id=f"bulk_id_{i}",
-                    )
-                    for i in range(5)
-                ]
-            ),
-        )
-        mocker.patch.object(
-            self.mock_client,
-            "create_media_objects",
-            return_value=models.BulkResponse(
-                results=[
-                    models.AnnotatableCreateResponse(
-                        status=models.ResponseStatesEnum.SUCCESS,
-                        bulk_operation_annotatable_id=f"bulk_id_{i}",
-                    )
-                    for i in range(10)
-                ]
-            ),
-        )
-
-        mocker.patch.object(
-            self.mock_client, "create_attributes", return_value=models.BulkResponse()
-        )
-
-        pedestrian_subset_id = str(uuid.uuid4())
-        wheel_subset_id = str(uuid.uuid4())
-        object_categories = {"pedestrian", "wheel"}
-        object_category_vs_subsets = {
-            "pedestrian": pedestrian_subset_id,
-            "wheel": wheel_subset_id,
-        }
-        mocker.patch.object(
-            self.mock_client,
-            "create_subset",
-            side_effect=[pedestrian_subset_id, wheel_subset_id],
-        )
-        dataset_response = models.DatasetResponse(
-            id=uuid.UUID(int=0),
-            name="my dataset",
-            num_medias=1,
-            num_media_objects=1,
-            num_instances=1,
-            mediatype=models.MediaType.IMAGE,
-        )
-        mocker.patch.object(
-            self.mock_client,
-            "get_subsets_for_dataset",
-            side_effect=[
-                [dataset_response],
-            ],
-        )
-        mock_uploader = hari_uploader.HARIUploader(
-            client=self.mock_client,
-            dataset_id=uuid.UUID(int=0),
-            object_categories_to_validate=object_categories,
-        )
-
-        global running_media_bulk_id
-        running_media_bulk_id = 0
-        global running_media_object_bulk_id
-        running_media_object_bulk_id = 0
-
-        def id_setter_mock(
-            item: hari_uploader.HARIMedia | hari_uploader.HARIMediaObject,
-        ):
-            global running_media_bulk_id
-            global running_media_object_bulk_id
-            if isinstance(item, hari_uploader.HARIMedia):
-                item.bulk_operation_annotatable_id = f"bulk_id_{running_media_bulk_id}"
-                running_media_bulk_id += 1
-            elif isinstance(item, hari_uploader.HARIMediaObject):
-                item.bulk_operation_annotatable_id = (
-                    f"bulk_id_{running_media_object_bulk_id}"
-                )
-                running_media_object_bulk_id += 1
-
-        mocker.patch.object(
-            mock_uploader,
-            "_set_bulk_operation_annotatable_id",
-            side_effect=id_setter_mock,
-        )
-        media_spy = mocker.spy(mock_uploader, "_upload_media_batch")
-        media_object_spy = mocker.spy(mock_uploader, "_upload_media_object_batch")
-        attribute_spy = mocker.spy(mock_uploader, "_upload_attribute_batch")
-
-        # 5 medias --> 1 batch
-        # 10 media_objects --> 1 batch
-        # 30 attributes --> 1 batch
-        for i in range(5):
-            media = hari_uploader.HARIMedia(
-                name=f"my image {i}",
-                media_type=models.MediaType.IMAGE,
-                back_reference=f"img_{i}",
-            )
-            for k in range(2):
-                media_object = hari_uploader.HARIMediaObject(
-                    source=models.DataSource.REFERENCE,
-                    back_reference=f"img_{i}_obj_{k}",
-                )
-                media.add_media_object(media_object)
-                media.add_attribute(
-                    hari_uploader.HARIAttribute(
-                        id=f"attr_{i}_{k}",
-                        name=f"attr_{i}_{k}",
-                        attribute_type=models.AttributeType.Categorical,
-                        value=f"value_{i}_{k}",
-                        attribute_group=models.AttributeGroup.InitialAttribute,
-                    )
-                )
-                for l in range(2):
-                    media_object.add_attribute(
-                        hari_uploader.HARIAttribute(
-                            id=f"attr_{i}_{k}_{l}",
-                            name=f"attr_{i}_{k}_{l}",
-                            attribute_type=models.AttributeType.Categorical,
-                            value=f"value_{i}_{k}_{l}",
-                            attribute_group=models.AttributeGroup.InitialAttribute,
-                        )
-                    )
-
-            mock_uploader.add_media(media)
-
-        # Act
-        mock_uploader.upload()
-
-        # Assert
-        # check every batch upload method's call
-        assert media_spy.call_count == 1
-        media_calls = media_spy.call_args_list
-        assert len(media_calls[0].kwargs["medias_to_upload"]) == 5
-        assert len(mock_uploader._medias) == 5
-
-        assert media_object_spy.call_count == 1
-        media_object_calls = media_object_spy.call_args_list
-        assert len(media_object_calls[0].kwargs["media_objects_to_upload"]) == 10
-        assert mock_uploader._media_object_cnt == 10
-
-        assert attribute_spy.call_count == 1
-        attribute_calls = attribute_spy.call_args_list
-        assert len(attribute_calls[0].kwargs["attributes_to_upload"]) == 30
-        assert mock_uploader._attribute_cnt == 30
-
-    def test_warning_for_hari_uploader_receives_duplicate_media_back_reference(
-        self, mocker
-    ):
-        # Arrange
-        log_spy = mocker.spy(hari_uploader.log, "warning")
-        self.uploader.add_media(
-            hari_uploader.HARIMedia(
-                name="my image 1",
-                media_type=models.MediaType.IMAGE,
-                back_reference="img_1",
-            )
-        )
-
-        # Act
-        self.uploader.add_media(
-            hari_uploader.HARIMedia(
-                name="my image 2",
-                media_type=models.MediaType.IMAGE,
-                back_reference="img_1",
-            )
-        )
-
-        # Assert
-        assert log_spy.call_count == 1
-
-    def test_warning_for_hari_uploader_receives_duplicate_media_object_back_reference(
-        self,
-        mocker,
-    ):
-        # Arrange
-        log_spy = mocker.spy(hari_uploader.log, "warning")
+    # 1100 medias --> 3 batches
+    # 2200 media_objects --> 5 batches
+    # 6600 attributes --> 14 batches
+    for i in range(1100):
         media = hari_uploader.HARIMedia(
-            name="my image 1", media_type=models.MediaType.IMAGE, back_reference="img_1"
-        )
-        media.add_media_object(
-            hari_uploader.HARIMediaObject(
-                source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
-            )
-        )
-        media.add_media_object(
-            hari_uploader.HARIMediaObject(
-                source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
-            )
-        )
-
-        # Act
-        self.uploader.add_media(media)
-
-        # Assert
-        assert log_spy.call_count == 1
-
-    def test_warning_for_media_without_back_reference(self, mocker):
-        # Arrange
-        log_spy = mocker.spy(hari_uploader.log, "warning")
-
-        # Act
-        hari_uploader.HARIMedia(
-            name="my image 1", media_type=models.MediaType.IMAGE, back_reference=""
-        )
-
-        # Assert
-        assert log_spy.call_count == 1
-
-    def test_warning_for_media_object_without_back_reference(self, mocker):
-        # Arrange
-        log_spy = mocker.spy(hari_uploader.log, "warning")
-
-        # Act
-        hari_uploader.HARIMediaObject(
-            source=models.DataSource.REFERENCE, back_reference=""
-        )
-
-        # Assert
-        assert log_spy.call_count == 1
-
-    def test_hari_uploader_sets_bulk_operation_annotatable_id_automatically_on_medias(
-        self,
-        mocker,
-    ):
-        # Arrange
-        mocker.patch.object(
-            self.mock_client,
-            "create_medias",
-            return_value=models.BulkResponse(
-                results=[
-                    models.AnnotatableCreateResponse(
-                        status=models.ResponseStatesEnum.SUCCESS,
-                        item_id="server_side_media_id",
-                        bulk_operation_annotatable_id="bulk_id",
-                    )
-                ]
-            ),
-        )
-        mocker.patch.object(
-            self.mock_client, "create_media_objects", return_value=models.BulkResponse()
-        )
-        pedestrian_subset_id = str(uuid.uuid4())
-        wheel_subset_id = str(uuid.uuid4())
-        object_categories = {"pedestrian", "wheel"}
-        object_category_vs_subsets = {
-            "pedestrian": pedestrian_subset_id,
-            "wheel": wheel_subset_id,
-        }
-        mocker.patch.object(
-            self.mock_client,
-            "create_subset",
-            side_effect=[pedestrian_subset_id, wheel_subset_id],
-        )
-        dataset_response = models.DatasetResponse(
-            id=uuid.UUID(int=0),
-            name="my dataset",
-            num_medias=1,
-            num_media_objects=1,
-            num_instances=1,
-            mediatype=models.MediaType.IMAGE,
-        )
-        mocker.patch.object(
-            self.mock_client,
-            "get_subsets_for_dataset",
-            side_effect=[
-                [dataset_response],
-            ],
-        )
-        mock_uploader = hari_uploader.HARIUploader(
-            client=self.mock_client,
-            dataset_id=uuid.UUID(int=0),
-            object_categories_to_validate=object_categories,
-        )
-
-        def id_setter_mock(
-            item: hari_uploader.HARIMedia | hari_uploader.HARIMediaObject,
-        ):
-            item.bulk_operation_annotatable_id = "bulk_id"
-
-        mocker.patch.object(
-            mock_uploader,
-            "_set_bulk_operation_annotatable_id",
-            side_effect=id_setter_mock,
-        )
-        id_setter_spy = mocker.spy(mock_uploader, "_set_bulk_operation_annotatable_id")
-
-        # 1 media with 1 media_object
-        media = hari_uploader.HARIMedia(
-            name="my image",
+            name=f"my image {i}",
             media_type=models.MediaType.IMAGE,
-            back_reference="img",
+            back_reference=f"img_{i}",
         )
-        media.add_media_object(
-            hari_uploader.HARIMediaObject(
+        for k in range(2):
+            media_object = hari_uploader.HARIMediaObject(
                 source=models.DataSource.REFERENCE,
-                back_reference="img_obj",
+                back_reference=f"img_{i}_obj_{k}",
             )
+            media.add_media_object(media_object)
+            media.add_attribute(
+                hari_uploader.HARIAttribute(
+                    id=f"attr_{i}_{k}",
+                    name=f"attr_{i}_{k}",
+                    attribute_type=models.AttributeType.Categorical,
+                    value=f"value_{i}_{k}",
+                    attribute_group=models.AttributeGroup.InitialAttribute,
+                )
+            )
+            for l in range(2):
+                media_object.add_attribute(
+                    hari_uploader.HARIAttribute(
+                        id=f"attr_{i}_{k}_{l}",
+                        name=f"attr_{i}_{k}_{l}",
+                        attribute_type=models.AttributeType.Categorical,
+                        value=f"value_{i}_{k}_{l}",
+                        attribute_group=models.AttributeGroup.InitialAttribute,
+                    )
+                )
+        uploader.add_media(media)
+
+    # Act
+    uploader.upload()
+
+    # Assert
+    # check every batch upload method's call
+    assert media_spy.call_count == 3
+    media_calls = media_spy.call_args_list
+    assert len(media_calls[0].kwargs["medias_to_upload"]) == 500
+    assert len(media_calls[1].kwargs["medias_to_upload"]) == 500
+    assert len(media_calls[2].kwargs["medias_to_upload"]) == 100
+    assert len(uploader._medias) == 1100
+
+    assert media_object_spy.call_count == 5
+    media_object_calls = media_object_spy.call_args_list
+    assert len(media_object_calls[0].kwargs["media_objects_to_upload"]) == 500
+    assert len(media_object_calls[1].kwargs["media_objects_to_upload"]) == 500
+    assert len(media_object_calls[2].kwargs["media_objects_to_upload"]) == 500
+    assert len(media_object_calls[3].kwargs["media_objects_to_upload"]) == 500
+    assert len(media_object_calls[4].kwargs["media_objects_to_upload"]) == 200
+    assert uploader._media_object_cnt == 2200
+
+    assert attribute_spy.call_count == 14
+    attribute_calls = attribute_spy.call_args_list
+    assert len(attribute_calls[0].kwargs["attributes_to_upload"]) == 500
+    assert len(attribute_calls[1].kwargs["attributes_to_upload"]) == 500
+    assert len(attribute_calls[2].kwargs["attributes_to_upload"]) == 500
+    assert len(attribute_calls[3].kwargs["attributes_to_upload"]) == 500
+    assert len(attribute_calls[4].kwargs["attributes_to_upload"]) == 500
+    assert len(attribute_calls[5].kwargs["attributes_to_upload"]) == 500
+    assert len(attribute_calls[6].kwargs["attributes_to_upload"]) == 500
+    assert len(attribute_calls[7].kwargs["attributes_to_upload"]) == 500
+    assert len(attribute_calls[8].kwargs["attributes_to_upload"]) == 500
+    assert len(attribute_calls[9].kwargs["attributes_to_upload"]) == 500
+    assert len(attribute_calls[10].kwargs["attributes_to_upload"]) == 500
+    assert len(attribute_calls[11].kwargs["attributes_to_upload"]) == 500
+    assert len(attribute_calls[12].kwargs["attributes_to_upload"]) == 500
+    assert len(attribute_calls[13].kwargs["attributes_to_upload"]) == 100
+    assert uploader._attribute_cnt == 6600
+
+
+def test_hari_uploader_creates_single_batch_correctly(mock_uploader_for_single_batch):
+    # Arrange
+    (
+        uploader,
+        media_spy,
+        media_object_spy,
+        attribute_spy,
+    ) = mock_uploader_for_single_batch
+
+    # 5 medias --> 1 batch
+    # 10 media_objects --> 1 batch
+    # 30 attributes --> 1 batch
+    for i in range(5):
+        media = hari_uploader.HARIMedia(
+            name=f"my image {i}",
+            media_type=models.MediaType.IMAGE,
+            back_reference=f"img_{i}",
         )
-        mock_uploader.add_media(media)
+        for k in range(2):
+            media_object = hari_uploader.HARIMediaObject(
+                source=models.DataSource.REFERENCE,
+                back_reference=f"img_{i}_obj_{k}",
+            )
+            media.add_media_object(media_object)
+            media.add_attribute(
+                hari_uploader.HARIAttribute(
+                    id=f"attr_{i}_{k}",
+                    name=f"attr_{i}_{k}",
+                    attribute_type=models.AttributeType.Categorical,
+                    value=f"value_{i}_{k}",
+                    attribute_group=models.AttributeGroup.InitialAttribute,
+                )
+            )
+            for l in range(2):
+                media_object.add_attribute(
+                    hari_uploader.HARIAttribute(
+                        id=f"attr_{i}_{k}_{l}",
+                        name=f"attr_{i}_{k}_{l}",
+                        attribute_type=models.AttributeType.Categorical,
+                        value=f"value_{i}_{k}_{l}",
+                        attribute_group=models.AttributeGroup.InitialAttribute,
+                    )
+                )
 
-        # Act
-        mock_uploader.upload()
+        uploader.add_media(media)
 
-        # Assert
-        # the bulk_operation_annotatable_id must be set on the media and media_object
-        assert id_setter_spy.call_count == 2
-        assert media.bulk_operation_annotatable_id == "bulk_id"
-        # it's ok that media and media object have the same bulk_id, because they're uploaded in separate batch operations
-        assert media.media_objects[0].bulk_operation_annotatable_id == "bulk_id"
+    # Act
+    uploader.upload()
 
-        # the media_id of the media_object must match the one provided by the create_medias
-        assert media.media_objects[0].media_id == "server_side_media_id"
+    # Assert
+    # check every batch upload method's call
+    assert media_spy.call_count == 1
+    media_calls = media_spy.call_args_list
+    assert len(media_calls[0].kwargs["medias_to_upload"]) == 5
+    assert len(uploader._medias) == 5
 
-    @pytest.mark.parametrize(
-        "bulk_responses, expected_merged_response",
-        [
-            ([], models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS)),
-            ([models.BulkResponse()], models.BulkResponse()),
-            (
-                [
-                    models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS),
-                    models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS),
-                ],
+    assert media_object_spy.call_count == 1
+    media_object_calls = media_object_spy.call_args_list
+    assert len(media_object_calls[0].kwargs["media_objects_to_upload"]) == 10
+    assert uploader._media_object_cnt == 10
+
+    assert attribute_spy.call_count == 1
+    attribute_calls = attribute_spy.call_args_list
+    assert len(attribute_calls[0].kwargs["attributes_to_upload"]) == 30
+    assert uploader._attribute_cnt == 30
+
+
+def test_warning_for_hari_uploader_receives_duplicate_media_back_reference(
+    mock_uploader_for_object_category_validation, mocker
+):
+    # Arrange
+    (
+        uploader,
+        object_categories_vs_subsets,
+    ) = mock_uploader_for_object_category_validation
+    log_spy = mocker.spy(hari_uploader.log, "warning")
+    uploader.add_media(
+        hari_uploader.HARIMedia(
+            name="my image 1",
+            media_type=models.MediaType.IMAGE,
+            back_reference="img_1",
+        )
+    )
+
+    # Act
+    uploader.add_media(
+        hari_uploader.HARIMedia(
+            name="my image 2",
+            media_type=models.MediaType.IMAGE,
+            back_reference="img_1",
+        )
+    )
+
+    # Assert
+    assert log_spy.call_count == 1
+
+
+def test_warning_for_hari_uploader_receives_duplicate_media_object_back_reference(
+    mock_uploader_for_object_category_validation,
+    mocker,
+):
+    # Arrange
+    (
+        uploader,
+        object_categories_vs_subsets,
+    ) = mock_uploader_for_object_category_validation
+    log_spy = mocker.spy(hari_uploader.log, "warning")
+    media = hari_uploader.HARIMedia(
+        name="my image 1", media_type=models.MediaType.IMAGE, back_reference="img_1"
+    )
+    media.add_media_object(
+        hari_uploader.HARIMediaObject(
+            source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
+        )
+    )
+    media.add_media_object(
+        hari_uploader.HARIMediaObject(
+            source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
+        )
+    )
+
+    # Act
+    uploader.add_media(media)
+
+    # Assert
+    assert log_spy.call_count == 1
+
+
+def test_warning_for_media_without_back_reference(mocker):
+    # Arrange
+    log_spy = mocker.spy(hari_uploader.log, "warning")
+
+    # Act
+    hari_uploader.HARIMedia(
+        name="my image 1", media_type=models.MediaType.IMAGE, back_reference=""
+    )
+
+    # Assert
+    assert log_spy.call_count == 1
+
+
+def test_warning_for_media_object_without_back_reference(mocker):
+    # Arrange
+    log_spy = mocker.spy(hari_uploader.log, "warning")
+
+    # Act
+    hari_uploader.HARIMediaObject(source=models.DataSource.REFERENCE, back_reference="")
+
+    # Assert
+    assert log_spy.call_count == 1
+
+
+def test_hari_uploader_sets_bulk_operation_annotatable_id_automatically_on_medias(
+    mock_uploader_for_bulk_operation_annotatable_id_setter,
+):
+    # Arrange
+    uploader, id_setter_spy = mock_uploader_for_bulk_operation_annotatable_id_setter
+
+    # Act
+    # 1 media with 1 media_object
+    media = hari_uploader.HARIMedia(
+        name="my image",
+        media_type=models.MediaType.IMAGE,
+        back_reference="img",
+    )
+    media.add_media_object(
+        hari_uploader.HARIMediaObject(
+            source=models.DataSource.REFERENCE,
+            back_reference="img_obj",
+        )
+    )
+    uploader.add_media(media)
+    uploader.upload()
+
+    # Assert
+    # the bulk_operation_annotatable_id must be set on the media and media_object
+    assert id_setter_spy.call_count == 2
+    assert media.bulk_operation_annotatable_id == "bulk_id"
+    # it's ok that media and media object have the same bulk_id, because they're uploaded in separate batch operations
+    assert media.media_objects[0].bulk_operation_annotatable_id == "bulk_id"
+
+    # the media_id of the media_object must match the one provided by the create_medias
+    assert media.media_objects[0].media_id == "server_side_media_id"
+
+
+@pytest.mark.parametrize(
+    "bulk_responses, expected_merged_response",
+    [
+        ([], models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS)),
+        ([models.BulkResponse()], models.BulkResponse()),
+        (
+            [
                 models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS),
-            ),
-            (
-                [
-                    models.BulkResponse(
-                        status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
-                    ),
-                    models.BulkResponse(
-                        status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
-                    ),
-                ],
+                models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS),
+            ],
+            models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS),
+        ),
+        (
+            [
                 models.BulkResponse(
                     status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
                 ),
-            ),
-            (
-                [
-                    models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
-                    models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
-                ],
+                models.BulkResponse(
+                    status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
+                ),
+            ],
+            models.BulkResponse(status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS),
+        ),
+        (
+            [
                 models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
-            ),
-            (
-                [
-                    models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
-                    models.BulkResponse(
-                        status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
-                    ),
-                ],
+                models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
+            ],
+            models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
+        ),
+        (
+            [
+                models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
                 models.BulkResponse(
                     status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
                 ),
-            ),
-            (
-                [
-                    models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
-                    models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS),
-                ],
-                models.BulkResponse(
-                    status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
-                ),
-            ),
-            (
-                [
-                    models.BulkResponse(
-                        status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS,
-                        summary=models.BulkUploadSuccessSummary(
-                            total=5000, successful=4000, failed=1000
-                        ),
-                    ),
-                    models.BulkResponse(
-                        status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS,
-                        summary=models.BulkUploadSuccessSummary(
-                            total=3000, successful=1000, failed=2000
-                        ),
-                    ),
-                ],
+            ],
+            models.BulkResponse(status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS),
+        ),
+        (
+            [
+                models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
+                models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS),
+            ],
+            models.BulkResponse(status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS),
+        ),
+        (
+            [
                 models.BulkResponse(
                     status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS,
                     summary=models.BulkUploadSuccessSummary(
-                        total=8000, successful=5000, failed=3000
+                        total=5000, successful=4000, failed=1000
                     ),
                 ),
+                models.BulkResponse(
+                    status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS,
+                    summary=models.BulkUploadSuccessSummary(
+                        total=3000, successful=1000, failed=2000
+                    ),
+                ),
+            ],
+            models.BulkResponse(
+                status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS,
+                summary=models.BulkUploadSuccessSummary(
+                    total=8000, successful=5000, failed=3000
+                ),
             ),
-            (
-                [
-                    models.BulkResponse(
-                        results=[
-                            models.AnnotatableCreateResponse(
-                                item_id="1",
-                                status=models.ResponseStatesEnum.SUCCESS,
-                                back_reference="back_ref_1",
-                                bulk_operation_annotatable_id="bulk_id_1",
-                            ),
-                            models.AnnotatableCreateResponse(
-                                item_id="2",
-                                status=models.ResponseStatesEnum.SUCCESS,
-                                back_reference="back_ref_2",
-                                bulk_operation_annotatable_id="bulk_id_2",
-                            ),
-                        ]
-                    ),
-                    models.BulkResponse(
-                        results=[
-                            models.AnnotatableCreateResponse(
-                                item_id="3",
-                                status=models.ResponseStatesEnum.SUCCESS,
-                                back_reference="back_ref_3",
-                                bulk_operation_annotatable_id="bulk_id_3",
-                            ),
-                            models.AnnotatableCreateResponse(
-                                item_id="4",
-                                status=models.ResponseStatesEnum.SUCCESS,
-                                back_reference="back_ref_4",
-                                bulk_operation_annotatable_id="bulk_id_4",
-                            ),
-                        ]
-                    ),
-                ],
+        ),
+        (
+            [
                 models.BulkResponse(
                     results=[
                         models.AnnotatableCreateResponse(
@@ -1031,6 +749,10 @@ class TestHariUploader:
                             back_reference="back_ref_2",
                             bulk_operation_annotatable_id="bulk_id_2",
                         ),
+                    ]
+                ),
+                models.BulkResponse(
+                    results=[
                         models.AnnotatableCreateResponse(
                             item_id="3",
                             status=models.ResponseStatesEnum.SUCCESS,
@@ -1045,36 +767,60 @@ class TestHariUploader:
                         ),
                     ]
                 ),
+            ],
+            models.BulkResponse(
+                results=[
+                    models.AnnotatableCreateResponse(
+                        item_id="1",
+                        status=models.ResponseStatesEnum.SUCCESS,
+                        back_reference="back_ref_1",
+                        bulk_operation_annotatable_id="bulk_id_1",
+                    ),
+                    models.AnnotatableCreateResponse(
+                        item_id="2",
+                        status=models.ResponseStatesEnum.SUCCESS,
+                        back_reference="back_ref_2",
+                        bulk_operation_annotatable_id="bulk_id_2",
+                    ),
+                    models.AnnotatableCreateResponse(
+                        item_id="3",
+                        status=models.ResponseStatesEnum.SUCCESS,
+                        back_reference="back_ref_3",
+                        bulk_operation_annotatable_id="bulk_id_3",
+                    ),
+                    models.AnnotatableCreateResponse(
+                        item_id="4",
+                        status=models.ResponseStatesEnum.SUCCESS,
+                        back_reference="back_ref_4",
+                        bulk_operation_annotatable_id="bulk_id_4",
+                    ),
+                ]
             ),
-        ],
+        ),
+    ],
+)
+def test_merge_bulk_responses(
+    bulk_responses: list[models.BulkResponse],
+    expected_merged_response: models.BulkResponse,
+):
+    actual_merged_response = hari_uploader._merge_bulk_responses(*bulk_responses)
+    assert actual_merged_response.status == expected_merged_response.status
+
+    assert (
+        actual_merged_response.summary.total == expected_merged_response.summary.total
     )
-    def test_merge_bulk_responses(
-        self,
-        bulk_responses: list[models.BulkResponse],
-        expected_merged_response: models.BulkResponse,
+    assert (
+        actual_merged_response.summary.successful
+        == expected_merged_response.summary.successful
+    )
+    assert (
+        actual_merged_response.summary.failed == expected_merged_response.summary.failed
+    )
+
+    assert len(actual_merged_response.results) == len(expected_merged_response.results)
+    for actual_result, expected_result in zip(
+        actual_merged_response.results, expected_merged_response.results
     ):
-        actual_merged_response = hari_uploader._merge_bulk_responses(*bulk_responses)
-        assert actual_merged_response.status == expected_merged_response.status
-
-        assert (
-            actual_merged_response.summary.total
-            == expected_merged_response.summary.total
-        )
-        assert (
-            actual_merged_response.summary.successful
-            == expected_merged_response.summary.successful
-        )
-        assert (
-            actual_merged_response.summary.failed
-            == expected_merged_response.summary.failed
-        )
-
-        assert len(actual_merged_response.results) == len(
-            expected_merged_response.results
-        )
-        for actual_result, expected_result in zip(
-            actual_merged_response.results, expected_merged_response.results
-        ):
-            assert actual_result.item_id == expected_result.item_id
-            assert actual_result.back_reference == expected_result.back_reference
-            assert actual_result.status == expected_result.status
+        assert actual_result.item_id == expected_result.item_id
+        assert actual_result.back_reference == expected_result.back_reference
+        assert actual_result.status == expected_result.status

--- a/tests/test_hari_uploader.py
+++ b/tests/test_hari_uploader.py
@@ -21,6 +21,13 @@ from hari_client import models
 
 
 class TestHariUploader:
+    """
+    Tests for the HARIUploader class.
+    How to use:
+    - check if an existing fixture can be used for your test
+        - if not, create a new fixture with a HariClient to prepare the test data
+    """
+
     @pytest.fixture()
     def test_client(self) -> None:
         self.test_config = Config(
@@ -34,10 +41,10 @@ class TestHariUploader:
 
     # TODO: more test setups, better names
     @pytest.fixture(autouse=True)
-    def setup_basic_uploader(
+    def mock_client_(
         self, test_client, mocker
     ) -> tuple[hari_uploader.HARIUploader, dict[str, str]]:
-        """Sets up a basic self.uploader with a mock client
+        """Sets up a basic uplader using object_categories
         returns
             self.uploader: HARIUploader instance
             object_category_vs_subsets: dict[str, str] mapping object category names to their subset ids
@@ -56,9 +63,9 @@ class TestHariUploader:
         self.uploader = hari_uploader.HARIUploader(
             client=self.mock_client,
             dataset_id=uuid.UUID(int=0),
-            object_categories=object_categories,
+            object_categories_to_validate=object_categories,
         )
-        assert self.uploader.object_categories == {
+        assert self.uploader.object_categories_to_validate == {
             "pedestrian",
             "wheel",
         }
@@ -68,7 +75,7 @@ class TestHariUploader:
         }
         assert self.uploader._object_category_subsets == {}
 
-    def test_add_media(self, setup_basic_uploader):
+    def test_add_media(self):
         # Arrange
 
         assert len(self.uploader._medias) == 0
@@ -109,7 +116,7 @@ class TestHariUploader:
         assert len(self.uploader._medias) == 2
         assert self.uploader._attribute_cnt == 1
 
-    def test_create_object_category_subset(self, setup_basic_uploader):
+    def test_create_object_category_subset(self):
         # Act
         obj_categories_to_create = [
             obj_cat for obj_cat in self.object_categories_vs_subsets.keys()
@@ -164,9 +171,7 @@ class TestHariUploader:
             == hari_uploader.HARIMediaObjectUnknownObjectCategorySubsetNameError
         )
 
-    def test_assign_media_objects_to_object_category_subsets(
-        self, setup_basic_uploader
-    ):
+    def test_assign_media_objects_to_object_category_subsets(self):
         # Arrange
         obj_cat_vs_subs_iter = iter(self.object_categories_vs_subsets.items())
         object_category_1, subset_1 = next(obj_cat_vs_subs_iter)
@@ -497,7 +502,7 @@ class TestHariUploader:
         mock_uploader = hari_uploader.HARIUploader(
             client=self.mock_client,
             dataset_id=uuid.UUID(int=0),
-            object_categories=object_categories,
+            object_categories_to_validate=object_categories,
         )
         mocker.patch.object(
             mock_uploader,
@@ -647,7 +652,7 @@ class TestHariUploader:
         mock_uploader = hari_uploader.HARIUploader(
             client=self.mock_client,
             dataset_id=uuid.UUID(int=0),
-            object_categories=object_categories,
+            object_categories_to_validate=object_categories,
         )
 
         global running_media_bulk_id
@@ -861,7 +866,7 @@ class TestHariUploader:
         mock_uploader = hari_uploader.HARIUploader(
             client=self.mock_client,
             dataset_id=uuid.UUID(int=0),
-            object_categories=object_categories,
+            object_categories_to_validate=object_categories,
         )
 
         def id_setter_mock(

--- a/tests/test_hari_uploader.py
+++ b/tests/test_hari_uploader.py
@@ -8,299 +8,233 @@ from hari_client import hari_uploader
 from hari_client import HARIClient
 from hari_client import models
 
-test_config = Config(
-    hari_username="username",
-    hari_password="password",
-    hari_api_base_url="api_base_url",
-    hari_client_id="client_id",
-    hari_auth_url="auth_url",
-)
-test_client = HARIClient(config=test_config)
+
+# TODO:
+#  - Add tests for the following methods:
+#    - object_categories in client initialization unset
+#       - media objects with object category name set
+#           - and without
+#    - object_categories in client initialization set
+#       - media objects with object category name set
+#           - and without
+# - starting an upload with non-eixstent object_categories on server - fail it, continue the upload
 
 
-@pytest.fixture()
-def setup_basic_uploader(mocker) -> tuple[hari_uploader.HARIUploader, dict[str, str]]:
-    """Sets up a basic uploader with a mock client
-    returns
-        uploader: HARIUploader instance
-        object_category_vs_subsets: dict[str, str] mapping object category names to their subset ids
-    """
-    pedestrian_subset_id = str(uuid.uuid4())
-    wheel_subset_id = str(uuid.uuid4())
-    object_categories = {"pedestrian", "wheel"}
-    object_category_vs_subsets = {
-        "pedestrian": pedestrian_subset_id,
-        "wheel": wheel_subset_id,
-    }
-    mock_client = HARIClient(config=test_config)
-    mocker.patch.object(
-        mock_client,
-        "create_subset",
-        side_effect=[pedestrian_subset_id, wheel_subset_id],
-    )
+class TestHariUploader:
+    @pytest.fixture()
+    def test_client(self) -> None:
+        self.test_config = Config(
+            hari_username="username",
+            hari_password="password",
+            hari_api_base_url="api_base_url",
+            hari_client_id="client_id",
+            hari_auth_url="auth_url",
+        )
+        self.test_client = HARIClient(config=self.test_config)
 
-    uploader = hari_uploader.HARIUploader(
-        client=mock_client,
-        dataset_id=uuid.UUID(int=0),
-        object_categories=object_categories,
-    )
-    assert uploader.object_categories == {
-        "pedestrian",
-        "wheel",
-    }
-    assert uploader._object_category_subsets == {}
-    return uploader, object_category_vs_subsets
+    # TODO: more test setups, better names
+    @pytest.fixture(autouse=True)
+    def setup_basic_uploader(
+        self, test_client, mocker
+    ) -> tuple[hari_uploader.HARIUploader, dict[str, str]]:
+        """Sets up a basic self.uploader with a mock client
+        returns
+            self.uploader: HARIUploader instance
+            object_category_vs_subsets: dict[str, str] mapping object category names to their subset ids
+        """
 
+        pedestrian_subset_id = str(uuid.uuid4())
+        wheel_subset_id = str(uuid.uuid4())
+        object_categories = {"pedestrian", "wheel"}
+        self.mock_client = HARIClient(config=self.test_config)
+        mocker.patch.object(
+            self.mock_client,
+            "create_subset",
+            side_effect=[pedestrian_subset_id, wheel_subset_id],
+        )
 
-def test_add_media():
-    # Arrange
-    uploader = hari_uploader.HARIUploader(
-        client=test_client, dataset_id=uuid.UUID(int=0)
-    )
-    assert len(uploader._medias) == 0
-    assert uploader._attribute_cnt == 0
+        self.uploader = hari_uploader.HARIUploader(
+            client=self.mock_client,
+            dataset_id=uuid.UUID(int=0),
+            object_categories=object_categories,
+        )
+        assert self.uploader.object_categories == {
+            "pedestrian",
+            "wheel",
+        }
+        self.object_categories_vs_subsets = {
+            "pedestrian": pedestrian_subset_id,
+            "wheel": wheel_subset_id,
+        }
+        assert self.uploader._object_category_subsets == {}
 
-    # Act
-    uploader.add_media(
-        hari_uploader.HARIMedia(
-            name="my image",
+    def test_add_media(self, setup_basic_uploader):
+        # Arrange
+
+        assert len(self.uploader._medias) == 0
+        assert self.uploader._attribute_cnt == 0
+
+        # Act
+        self.uploader.add_media(
+            hari_uploader.HARIMedia(
+                name="my image",
+                media_type=models.MediaType.IMAGE,
+                back_reference="img",
+                attributes=[
+                    hari_uploader.HARIAttribute(
+                        id="attr_1",
+                        name="my attribute 1",
+                        attribute_type=models.AttributeType.Categorical,
+                        value="value 1",
+                        attribute_group=models.AttributeGroup.InitialAttribute,
+                    )
+                ],
+            )
+        )
+
+        # Assert
+        assert len(self.uploader._medias) == 1
+        assert self.uploader._attribute_cnt == 1
+
+        # Act
+        # add another media without attributes
+        self.uploader.add_media(
+            hari_uploader.HARIMedia(
+                name="my image",
+                media_type=models.MediaType.IMAGE,
+                back_reference="img",
+            )
+        )
+        # Assert
+        assert len(self.uploader._medias) == 2
+        assert self.uploader._attribute_cnt == 1
+
+    def test_create_object_category_subset(self, setup_basic_uploader):
+        # Act
+        obj_categories_to_create = [
+            obj_cat for obj_cat in self.object_categories_vs_subsets.keys()
+        ]
+        self.uploader._create_object_category_subsets(obj_categories_to_create)
+
+        # Assert
+        assert (
+            self.uploader._object_category_subsets == self.object_categories_vs_subsets
+        )
+
+    def test_validate_media_objects_object_category_subsets_consistency(
+        self,
+    ):
+        # Arrange
+        media_1 = hari_uploader.HARIMedia(
+            name="my image 1",
             media_type=models.MediaType.IMAGE,
-            back_reference="img",
-            attributes=[
-                hari_uploader.HARIAttribute(
-                    id="attr_1",
-                    name="my attribute 1",
-                    attribute_type=models.AttributeType.Categorical,
-                    value="value 1",
-                    attribute_group=models.AttributeGroup.InitialAttribute,
-                )
-            ],
+            back_reference="img_1",
+            object_category_subset_name="pedestrian",
         )
-    )
-
-    # Assert
-    assert len(uploader._medias) == 1
-    assert uploader._attribute_cnt == 1
-
-    # Act
-    # add another media without attributes
-    uploader.add_media(
-        hari_uploader.HARIMedia(
-            name="my image",
-            media_type=models.MediaType.IMAGE,
-            back_reference="img",
-        )
-    )
-    # Assert
-    assert len(uploader._medias) == 2
-    assert uploader._attribute_cnt == 1
-
-
-def test_create_object_category_subset(setup_basic_uploader):
-    # Arrange
-    uploader, object_categories_vs_subsets = setup_basic_uploader
-
-    # Act
-    obj_categories_to_create = [
-        obj_cat for obj_cat in object_categories_vs_subsets.keys()
-    ]
-    uploader._create_object_category_subsets(obj_categories_to_create)
-
-    # Assert
-    assert uploader._object_category_subsets == object_categories_vs_subsets
-
-
-def test_validate_media_objects_object_category_subsets_consistency():
-    # Arrange
-    object_categories = {
-        "pedestrian",
-    }
-
-    uploader = hari_uploader.HARIUploader(
-        client=test_client,
-        dataset_id=uuid.UUID(int=0),
-        object_categories=object_categories,
-    )
-
-    media_1 = hari_uploader.HARIMedia(
-        name="my image 1",
-        media_type=models.MediaType.IMAGE,
-        back_reference="img_1",
-        object_category_subset_name="pedestrian",
-    )
-    media_object_1 = hari_uploader.HARIMediaObject(
-        source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
-    )
-    media_object_1.set_object_category_subset_name("pedestrian")
-    media_1.add_media_object(media_object_1)
-    uploader.add_media(media_1)
-    # Act
-    errors = uploader._validate_media_objects_object_category_subsets_consistency()
-
-    # Assert
-    assert len(errors) == 0
-
-    # Arrange
-    media_object_2 = hari_uploader.HARIMediaObject(
-        source=models.DataSource.REFERENCE, back_reference="img_1_obj_2"
-    )
-    media_object_2.set_object_category_subset_name("wheel")
-    media_1.add_media_object(media_object_2)
-
-    # Act
-
-    # Assert
-    errors = uploader._validate_media_objects_object_category_subsets_consistency()
-    assert len(errors) == 1
-    assert (
-        type(errors[0])
-        == hari_uploader.HARIMediaObjectUnknownObjectCategorySubsetNameError
-    )
-
-
-def test_assign_media_objects_to_object_category_subsets(setup_basic_uploader):
-    # Arrange
-    uploader, object_categories_vs_subsets = setup_basic_uploader
-    obj_cat_vs_subs_iter = iter(object_categories_vs_subsets.items())
-    object_category_1, subset_1 = next(obj_cat_vs_subs_iter)
-    object_category_2, subset_2 = next(obj_cat_vs_subs_iter)
-
-    media_1 = hari_uploader.HARIMedia(
-        name="my image 1",
-        media_type=models.MediaType.IMAGE,
-        back_reference="img_1",
-        object_category_subset_name="pedestrian",
-    )
-    media_object_1 = hari_uploader.HARIMediaObject(
-        source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
-    )
-    media_object_1.set_object_category_subset_name("pedestrian")
-    media_1.add_media_object(media_object_1)
-    media_object_2 = hari_uploader.HARIMediaObject(
-        source=models.DataSource.REFERENCE, back_reference="img_1_obj_2"
-    )
-    media_object_2.set_object_category_subset_name("wheel")
-    media_1.add_media_object(media_object_2)
-    uploader.add_media(media_1)
-
-    # Act
-    obj_categories_to_create = [
-        obj_cat for obj_cat in object_categories_vs_subsets.keys()
-    ]
-    uploader._create_object_category_subsets(obj_categories_to_create)
-    uploader._assign_object_category_subsets()
-
-    # Assert
-    for media in uploader._medias:
-        for media_object in media.media_objects:
-            if media_object.object_category_subset_name == object_category_1:
-                assert media_object.subset_ids == [subset_1]
-            elif media_object.object_category_subset_name == object_category_2:
-                assert media_object.subset_ids == [subset_2]
-        assert collections.Counter(media.subset_ids) == collections.Counter(
-            [subset_1, subset_2]
-        )
-
-
-def test_update_hari_media_object_media_ids():
-    # Arrange
-    uploader = hari_uploader.HARIUploader(
-        client=test_client, dataset_id=uuid.UUID(int=0)
-    )
-    media_1 = hari_uploader.HARIMedia(
-        name="my image 1",
-        media_type=models.MediaType.IMAGE,
-        back_reference="img_1",
-    )
-    media_1.bulk_operation_annotatable_id = "bulk_id_1"
-    media_1.add_media_object(
-        hari_uploader.HARIMediaObject(
+        media_object_1 = hari_uploader.HARIMediaObject(
             source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
         )
-    )
-    uploader.add_media(media_1)
-    media_2 = hari_uploader.HARIMedia(
-        name="my image 2",
-        media_type=models.MediaType.IMAGE,
-        back_reference="img_2",
-    )
-    media_2.bulk_operation_annotatable_id = "bulk_id_2"
-    media_2.add_media_object(
-        hari_uploader.HARIMediaObject(
-            source=models.DataSource.REFERENCE, back_reference="img_2_obj_1"
+        media_object_1.set_object_category_subset_name("pedestrian")
+        media_1.add_media_object(media_object_1)
+        self.uploader.add_media(media_1)
+        # Act
+        errors = (
+            self.uploader._validate_media_objects_object_category_subsets_consistency()
         )
-    )
-    uploader.add_media(media_2)
-    media_upload_bulk_response = models.BulkResponse(
-        results=[
-            models.AnnotatableCreateResponse(
-                item_id="new_media_id_1",
-                back_reference="img_1",
-                bulk_operation_annotatable_id="bulk_id_1",
-                status=models.ResponseStatesEnum.SUCCESS,
-            ),
-            models.AnnotatableCreateResponse(
-                item_id="new_media_id_2",
-                back_reference="img_2",
-                bulk_operation_annotatable_id="bulk_id_2",
-                status=models.ResponseStatesEnum.SUCCESS,
-            ),
+
+        # Assert
+        assert len(errors) == 0
+
+        # Arrange
+        media_object_2 = hari_uploader.HARIMediaObject(
+            source=models.DataSource.REFERENCE, back_reference="img_1_obj_2"
+        )
+        media_object_2.set_object_category_subset_name("some_non-existent-subset_name")
+        media_1.add_media_object(media_object_2)
+
+        # Act
+
+        # Assert
+        errors = (
+            self.uploader._validate_media_objects_object_category_subsets_consistency()
+        )
+        assert len(errors) == 1
+        assert (
+            type(errors[0])
+            == hari_uploader.HARIMediaObjectUnknownObjectCategorySubsetNameError
+        )
+
+    def test_assign_media_objects_to_object_category_subsets(
+        self, setup_basic_uploader
+    ):
+        # Arrange
+        obj_cat_vs_subs_iter = iter(self.object_categories_vs_subsets.items())
+        object_category_1, subset_1 = next(obj_cat_vs_subs_iter)
+        object_category_2, subset_2 = next(obj_cat_vs_subs_iter)
+
+        media_1 = hari_uploader.HARIMedia(
+            name="my image 1",
+            media_type=models.MediaType.IMAGE,
+            back_reference="img_1",
+            object_category_subset_name="pedestrian",
+        )
+        media_object_1 = hari_uploader.HARIMediaObject(
+            source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
+        )
+        media_object_1.set_object_category_subset_name("pedestrian")
+        media_1.add_media_object(media_object_1)
+        media_object_2 = hari_uploader.HARIMediaObject(
+            source=models.DataSource.REFERENCE, back_reference="img_1_obj_2"
+        )
+        media_object_2.set_object_category_subset_name("wheel")
+        media_1.add_media_object(media_object_2)
+        self.uploader.add_media(media_1)
+
+        # Act
+        obj_categories_to_create = [
+            obj_cat for obj_cat in self.object_categories_vs_subsets.keys()
         ]
-    )
+        self.uploader._create_object_category_subsets(obj_categories_to_create)
+        self.uploader._assign_object_category_subsets()
 
-    # Act
-    uploader._update_hari_media_object_media_ids(
-        medias_to_upload=[media_1, media_2],
-        media_upload_bulk_response=media_upload_bulk_response,
-    )
+        # Assert
+        for media in self.uploader._medias:
+            for media_object in media.media_objects:
+                if media_object.object_category_subset_name == object_category_1:
+                    assert media_object.subset_ids == [subset_1]
+                elif media_object.object_category_subset_name == object_category_2:
+                    assert media_object.subset_ids == [subset_2]
+            assert collections.Counter(media.subset_ids) == collections.Counter(
+                [subset_1, subset_2]
+            )
 
-    # Assert
-    assert uploader._medias[0].media_objects[0].media_id == "new_media_id_1"
-    assert uploader._medias[1].media_objects[0].media_id == "new_media_id_2"
-
-
-def test_update_hari_attribute_media_ids():
-    # Arrange
-    uploader = hari_uploader.HARIUploader(
-        client=test_client, dataset_id=uuid.UUID(int=0)
-    )
-    media_1 = hari_uploader.HARIMedia(
-        name="my image 1",
-        media_type=models.MediaType.IMAGE,
-        back_reference="img_1",
-    )
-    media_1.bulk_operation_annotatable_id = "bulk_id_1"
-    media_1.add_attribute(
-        hari_uploader.HARIAttribute(
-            id="attr_1",
-            name="my attribute 1",
-            attribute_type=models.AttributeType.Categorical,
-            value="value 1",
-            attribute_group=models.AttributeGroup.InitialAttribute,
+    def test_update_hari_media_object_media_ids(self):
+        # Arrange
+        media_1 = hari_uploader.HARIMedia(
+            name="my image 1",
+            media_type=models.MediaType.IMAGE,
+            back_reference="img_1",
         )
-    )
-    uploader.add_media(media_1)
-    media_2 = hari_uploader.HARIMedia(
-        name="my image 2",
-        media_type=models.MediaType.IMAGE,
-        back_reference="img_2",
-    )
-    media_2.bulk_operation_annotatable_id = "bulk_id_2"
-    media_2.add_attribute(
-        hari_uploader.HARIAttribute(
-            id="attr_1",
-            name="my attribute 2",
-            attribute_type=models.AttributeType.Categorical,
-            value="value 2",
-            attribute_group=models.AttributeGroup.InitialAttribute,
+        media_1.bulk_operation_annotatable_id = "bulk_id_1"
+        media_1.add_media_object(
+            hari_uploader.HARIMediaObject(
+                source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
+            )
         )
-    )
-    uploader.add_media(media_2)
-
-    # Act
-    uploader._update_hari_attribute_media_ids(
-        medias_to_upload=[media_1, media_2],
-        media_upload_bulk_response=models.BulkResponse(
+        self.uploader.add_media(media_1)
+        media_2 = hari_uploader.HARIMedia(
+            name="my image 2",
+            media_type=models.MediaType.IMAGE,
+            back_reference="img_2",
+        )
+        media_2.bulk_operation_annotatable_id = "bulk_id_2"
+        media_2.add_media_object(
+            hari_uploader.HARIMediaObject(
+                source=models.DataSource.REFERENCE, back_reference="img_2_obj_1"
+            )
+        )
+        self.uploader.add_media(media_2)
+        media_upload_bulk_response = models.BulkResponse(
             results=[
                 models.AnnotatableCreateResponse(
                     item_id="new_media_id_1",
@@ -315,669 +249,769 @@ def test_update_hari_attribute_media_ids():
                     status=models.ResponseStatesEnum.SUCCESS,
                 ),
             ]
-        ),
-    )
-
-    # Assert
-    assert media_1.attributes[0].annotatable_id == "new_media_id_1"
-    assert media_1.attributes[0].annotatable_type == models.DataBaseObjectType.MEDIA
-    assert media_2.attributes[0].annotatable_id == "new_media_id_2"
-    assert media_2.attributes[0].annotatable_type == models.DataBaseObjectType.MEDIA
-    assert uploader._attribute_cnt == 2
-
-
-def test_update_hari_attribute_media_object_ids():
-    # Arrange
-    uploader = hari_uploader.HARIUploader(
-        client=test_client, dataset_id=uuid.UUID(int=0)
-    )
-    media_1 = hari_uploader.HARIMedia(
-        name="my image 1",
-        media_type=models.MediaType.IMAGE,
-        back_reference="img_1",
-    )
-    media_object_1 = hari_uploader.HARIMediaObject(
-        source=models.DataSource.REFERENCE,
-        back_reference="img_1_obj_1",
-        reference_data=models.BBox2DCenterPoint(
-            type=models.BBox2DType.BBOX2D_CENTER_POINT,
-            x=1400.0,
-            y=1806.0,
-            width=344.0,
-            height=732.0,
-        ),
-    )
-    media_object_1.bulk_operation_annotatable_id = "bulk_id_1"
-    attribute_object_1 = hari_uploader.HARIAttribute(
-        id="attr_1",
-        name="Is human?",
-        attribute_type=models.AttributeType.Categorical,
-        value="yes",
-        attribute_group=models.AttributeGroup.InitialAttribute,
-    )
-    media_object_1.add_attribute(attribute_object_1)
-    media_1.add_media_object(media_object_1)
-
-    media_2 = hari_uploader.HARIMedia(
-        name="my image 2",
-        media_type=models.MediaType.IMAGE,
-        back_reference="img_2",
-    )
-    media_object_2 = hari_uploader.HARIMediaObject(
-        source=models.DataSource.REFERENCE,
-        back_reference="img_2_obj_1",
-        reference_data=models.BBox2DCenterPoint(
-            type=models.BBox2DType.BBOX2D_CENTER_POINT,
-            x=1400.0,
-            y=1806.0,
-            width=344.0,
-            height=732.0,
-        ),
-    )
-    media_object_2.bulk_operation_annotatable_id = "bulk_id_2"
-    attribute_object_2 = hari_uploader.HARIAttribute(
-        id="attr_1",
-        name="Is human?",
-        attribute_type=models.AttributeType.Categorical,
-        value="yes",
-        attribute_group=models.AttributeGroup.InitialAttribute,
-    )
-    media_object_2.add_attribute(attribute_object_2)
-    media_2.add_media_object(media_object_2)
-
-    # Act
-    uploader._update_hari_attribute_media_object_ids(
-        media_objects_to_upload=[media_object_1, media_object_2],
-        media_object_upload_bulk_response=models.BulkResponse(
-            results=[
-                models.AnnotatableCreateResponse(
-                    item_id="new_media_object_id_1",
-                    back_reference="img_1_obj_1",
-                    bulk_operation_annotatable_id="bulk_id_1",
-                    status=models.ResponseStatesEnum.SUCCESS,
-                ),
-                models.AnnotatableCreateResponse(
-                    item_id="new_media_object_id_2",
-                    back_reference="img_2_obj_1",
-                    bulk_operation_annotatable_id="bulk_id_2",
-                    status=models.ResponseStatesEnum.SUCCESS,
-                ),
-            ]
-        ),
-    )
-
-    # Assert
-    assert media_object_1.attributes[0].annotatable_id == "new_media_object_id_1"
-    assert (
-        media_object_1.attributes[0].annotatable_type
-        == models.DataBaseObjectType.MEDIAOBJECT
-    )
-    assert media_object_2.attributes[0].annotatable_id == "new_media_object_id_2"
-    assert (
-        media_object_2.attributes[0].annotatable_type
-        == models.DataBaseObjectType.MEDIAOBJECT
-    )
-
-
-def test_hari_uploader_creates_batches_correctly(mocker):
-    # Arrange
-    # setup mock_client and mock_uploader that allow for testing the full upload method
-    mock_client = HARIClient(config=test_config)
-    mocker.patch.object(
-        mock_client,
-        "create_medias",
-        return_value=models.BulkResponse(
-            results=[
-                models.AnnotatableCreateResponse(
-                    status=models.ResponseStatesEnum.SUCCESS,
-                    bulk_operation_annotatable_id=f"bulk_id_{i}",
-                )
-                for i in range(1100)
-            ]
-        ),
-    )
-    mocker.patch.object(
-        mock_client,
-        "create_media_objects",
-        return_value=models.BulkResponse(
-            results=[
-                models.AnnotatableCreateResponse(
-                    status=models.ResponseStatesEnum.SUCCESS,
-                    bulk_operation_annotatable_id=f"bulk_id_{i}",
-                )
-                for i in range(2200)
-            ]
-        ),
-    )
-    mocker.patch.object(
-        mock_client, "create_attributes", return_value=models.BulkResponse()
-    )
-    pedestrian_subset_id = str(uuid.uuid4())
-    wheel_subset_id = str(uuid.uuid4())
-    object_categories = {"pedestrian", "wheel"}
-    object_category_vs_subsets = {
-        "pedestrian": pedestrian_subset_id,
-        "wheel": wheel_subset_id,
-    }
-    mocker.patch.object(
-        mock_client,
-        "create_subset",
-        side_effect=[pedestrian_subset_id, wheel_subset_id],
-    )
-    dataset_response = models.DatasetResponse(
-        id=uuid.UUID(int=0),
-        name="my dataset",
-        num_medias=1,
-        num_media_objects=1,
-        num_instances=1,
-        mediatype=models.MediaType.IMAGE,
-    )
-    mocker.patch.object(
-        mock_client,
-        "get_subsets_for_dataset",
-        side_effect=[
-            [dataset_response],
-        ],
-    )
-
-    # there are multiple batches of medias and media objects, but the bulk_ids for the medias are expected to be continuous
-    # as implemented in the create_medias mock above.
-    global running_media_bulk_id
-    running_media_bulk_id = 0
-    global running_media_object_bulk_id
-    running_media_object_bulk_id = 0
-
-    def id_setter_mock(item: hari_uploader.HARIMedia | hari_uploader.HARIMediaObject):
-        global running_media_bulk_id
-        global running_media_object_bulk_id
-        if isinstance(item, hari_uploader.HARIMedia):
-            item.bulk_operation_annotatable_id = f"bulk_id_{running_media_bulk_id}"
-            running_media_bulk_id += 1
-        elif isinstance(item, hari_uploader.HARIMediaObject):
-            item.bulk_operation_annotatable_id = (
-                f"bulk_id_{running_media_object_bulk_id}"
-            )
-            running_media_object_bulk_id += 1
-
-    mock_uploader = hari_uploader.HARIUploader(
-        client=mock_client,
-        dataset_id=uuid.UUID(int=0),
-        object_categories=object_categories,
-    )
-    mocker.patch.object(
-        mock_uploader, "_set_bulk_operation_annotatable_id", side_effect=id_setter_mock
-    )
-    media_spy = mocker.spy(mock_uploader, "_upload_media_batch")
-    media_object_spy = mocker.spy(mock_uploader, "_upload_media_object_batch")
-    attribute_spy = mocker.spy(mock_uploader, "_upload_attribute_batch")
-
-    # 1100 medias --> 3 batches
-    # 2200 media_objects --> 5 batches
-    # 6600 attributes --> 14 batches
-    for i in range(1100):
-        media = hari_uploader.HARIMedia(
-            name=f"my image {i}",
-            media_type=models.MediaType.IMAGE,
-            back_reference=f"img_{i}",
         )
-        for k in range(2):
-            media_object = hari_uploader.HARIMediaObject(
-                source=models.DataSource.REFERENCE,
-                back_reference=f"img_{i}_obj_{k}",
-            )
-            media.add_media_object(media_object)
-            media.add_attribute(
-                hari_uploader.HARIAttribute(
-                    id=f"attr_{i}_{k}",
-                    name=f"attr_{i}_{k}",
-                    attribute_type=models.AttributeType.Categorical,
-                    value=f"value_{i}_{k}",
-                    attribute_group=models.AttributeGroup.InitialAttribute,
-                )
-            )
-            for l in range(2):
-                media_object.add_attribute(
-                    hari_uploader.HARIAttribute(
-                        id=f"attr_{i}_{k}_{l}",
-                        name=f"attr_{i}_{k}_{l}",
-                        attribute_type=models.AttributeType.Categorical,
-                        value=f"value_{i}_{k}_{l}",
-                        attribute_group=models.AttributeGroup.InitialAttribute,
-                    )
-                )
-        mock_uploader.add_media(media)
 
-    # Act
-    mock_uploader.upload()
-
-    # Assert
-    # check every batch upload method's call
-    assert media_spy.call_count == 3
-    media_calls = media_spy.call_args_list
-    assert len(media_calls[0].kwargs["medias_to_upload"]) == 500
-    assert len(media_calls[1].kwargs["medias_to_upload"]) == 500
-    assert len(media_calls[2].kwargs["medias_to_upload"]) == 100
-    assert len(mock_uploader._medias) == 1100
-
-    assert media_object_spy.call_count == 5
-    media_object_calls = media_object_spy.call_args_list
-    assert len(media_object_calls[0].kwargs["media_objects_to_upload"]) == 500
-    assert len(media_object_calls[1].kwargs["media_objects_to_upload"]) == 500
-    assert len(media_object_calls[2].kwargs["media_objects_to_upload"]) == 500
-    assert len(media_object_calls[3].kwargs["media_objects_to_upload"]) == 500
-    assert len(media_object_calls[4].kwargs["media_objects_to_upload"]) == 200
-    assert mock_uploader._media_object_cnt == 2200
-
-    assert attribute_spy.call_count == 14
-    attribute_calls = attribute_spy.call_args_list
-    assert len(attribute_calls[0].kwargs["attributes_to_upload"]) == 500
-    assert len(attribute_calls[1].kwargs["attributes_to_upload"]) == 500
-    assert len(attribute_calls[2].kwargs["attributes_to_upload"]) == 500
-    assert len(attribute_calls[3].kwargs["attributes_to_upload"]) == 500
-    assert len(attribute_calls[4].kwargs["attributes_to_upload"]) == 500
-    assert len(attribute_calls[5].kwargs["attributes_to_upload"]) == 500
-    assert len(attribute_calls[6].kwargs["attributes_to_upload"]) == 500
-    assert len(attribute_calls[7].kwargs["attributes_to_upload"]) == 500
-    assert len(attribute_calls[8].kwargs["attributes_to_upload"]) == 500
-    assert len(attribute_calls[9].kwargs["attributes_to_upload"]) == 500
-    assert len(attribute_calls[10].kwargs["attributes_to_upload"]) == 500
-    assert len(attribute_calls[11].kwargs["attributes_to_upload"]) == 500
-    assert len(attribute_calls[12].kwargs["attributes_to_upload"]) == 500
-    assert len(attribute_calls[13].kwargs["attributes_to_upload"]) == 100
-    assert mock_uploader._attribute_cnt == 6600
-
-
-def test_hari_uploader_creates_single_batch_correctly(mocker):
-    # Arrange
-    # setup mock_client and mock_uploader that allow for testing the full upload method
-    mock_client = HARIClient(config=test_config)
-    mocker.patch.object(
-        mock_client,
-        "create_medias",
-        return_value=models.BulkResponse(
-            results=[
-                models.AnnotatableCreateResponse(
-                    status=models.ResponseStatesEnum.SUCCESS,
-                    bulk_operation_annotatable_id=f"bulk_id_{i}",
-                )
-                for i in range(5)
-            ]
-        ),
-    )
-    mocker.patch.object(
-        mock_client,
-        "create_media_objects",
-        return_value=models.BulkResponse(
-            results=[
-                models.AnnotatableCreateResponse(
-                    status=models.ResponseStatesEnum.SUCCESS,
-                    bulk_operation_annotatable_id=f"bulk_id_{i}",
-                )
-                for i in range(10)
-            ]
-        ),
-    )
-
-    mocker.patch.object(
-        mock_client, "create_attributes", return_value=models.BulkResponse()
-    )
-
-    pedestrian_subset_id = str(uuid.uuid4())
-    wheel_subset_id = str(uuid.uuid4())
-    object_categories = {"pedestrian", "wheel"}
-    object_category_vs_subsets = {
-        "pedestrian": pedestrian_subset_id,
-        "wheel": wheel_subset_id,
-    }
-    mocker.patch.object(
-        mock_client,
-        "create_subset",
-        side_effect=[pedestrian_subset_id, wheel_subset_id],
-    )
-    dataset_response = models.DatasetResponse(
-        id=uuid.UUID(int=0),
-        name="my dataset",
-        num_medias=1,
-        num_media_objects=1,
-        num_instances=1,
-        mediatype=models.MediaType.IMAGE,
-    )
-    mocker.patch.object(
-        mock_client,
-        "get_subsets_for_dataset",
-        side_effect=[
-            [dataset_response],
-        ],
-    )
-    mock_uploader = hari_uploader.HARIUploader(
-        client=mock_client,
-        dataset_id=uuid.UUID(int=0),
-        object_categories=object_categories,
-    )
-
-    global running_media_bulk_id
-    running_media_bulk_id = 0
-    global running_media_object_bulk_id
-    running_media_object_bulk_id = 0
-
-    def id_setter_mock(item: hari_uploader.HARIMedia | hari_uploader.HARIMediaObject):
-        global running_media_bulk_id
-        global running_media_object_bulk_id
-        if isinstance(item, hari_uploader.HARIMedia):
-            item.bulk_operation_annotatable_id = f"bulk_id_{running_media_bulk_id}"
-            running_media_bulk_id += 1
-        elif isinstance(item, hari_uploader.HARIMediaObject):
-            item.bulk_operation_annotatable_id = (
-                f"bulk_id_{running_media_object_bulk_id}"
-            )
-            running_media_object_bulk_id += 1
-
-    mocker.patch.object(
-        mock_uploader, "_set_bulk_operation_annotatable_id", side_effect=id_setter_mock
-    )
-    media_spy = mocker.spy(mock_uploader, "_upload_media_batch")
-    media_object_spy = mocker.spy(mock_uploader, "_upload_media_object_batch")
-    attribute_spy = mocker.spy(mock_uploader, "_upload_attribute_batch")
-
-    # 5 medias --> 1 batch
-    # 10 media_objects --> 1 batch
-    # 30 attributes --> 1 batch
-    for i in range(5):
-        media = hari_uploader.HARIMedia(
-            name=f"my image {i}",
-            media_type=models.MediaType.IMAGE,
-            back_reference=f"img_{i}",
+        # Act
+        self.uploader._update_hari_media_object_media_ids(
+            medias_to_upload=[media_1, media_2],
+            media_upload_bulk_response=media_upload_bulk_response,
         )
-        for k in range(2):
-            media_object = hari_uploader.HARIMediaObject(
-                source=models.DataSource.REFERENCE,
-                back_reference=f"img_{i}_obj_{k}",
-            )
-            media.add_media_object(media_object)
-            media.add_attribute(
-                hari_uploader.HARIAttribute(
-                    id=f"attr_{i}_{k}",
-                    name=f"attr_{i}_{k}",
-                    attribute_type=models.AttributeType.Categorical,
-                    value=f"value_{i}_{k}",
-                    attribute_group=models.AttributeGroup.InitialAttribute,
-                )
-            )
-            for l in range(2):
-                media_object.add_attribute(
-                    hari_uploader.HARIAttribute(
-                        id=f"attr_{i}_{k}_{l}",
-                        name=f"attr_{i}_{k}_{l}",
-                        attribute_type=models.AttributeType.Categorical,
-                        value=f"value_{i}_{k}_{l}",
-                        attribute_group=models.AttributeGroup.InitialAttribute,
-                    )
-                )
 
-        mock_uploader.add_media(media)
+        # Assert
+        assert self.uploader._medias[0].media_objects[0].media_id == "new_media_id_1"
+        assert self.uploader._medias[1].media_objects[0].media_id == "new_media_id_2"
 
-    # Act
-    mock_uploader.upload()
-
-    # Assert
-    # check every batch upload method's call
-    assert media_spy.call_count == 1
-    media_calls = media_spy.call_args_list
-    assert len(media_calls[0].kwargs["medias_to_upload"]) == 5
-    assert len(mock_uploader._medias) == 5
-
-    assert media_object_spy.call_count == 1
-    media_object_calls = media_object_spy.call_args_list
-    assert len(media_object_calls[0].kwargs["media_objects_to_upload"]) == 10
-    assert mock_uploader._media_object_cnt == 10
-
-    assert attribute_spy.call_count == 1
-    attribute_calls = attribute_spy.call_args_list
-    assert len(attribute_calls[0].kwargs["attributes_to_upload"]) == 30
-    assert mock_uploader._attribute_cnt == 30
-
-
-def test_warning_for_hari_uploader_receives_duplicate_media_back_reference(mocker):
-    # Arrange
-    log_spy = mocker.spy(hari_uploader.log, "warning")
-    uploader = hari_uploader.HARIUploader(
-        client=test_client, dataset_id=uuid.UUID(int=0)
-    )
-    uploader.add_media(
-        hari_uploader.HARIMedia(
+    def test_update_hari_attribute_media_ids(self):
+        # Arrange
+        media_1 = hari_uploader.HARIMedia(
             name="my image 1",
             media_type=models.MediaType.IMAGE,
             back_reference="img_1",
         )
-    )
-
-    # Act
-    uploader.add_media(
-        hari_uploader.HARIMedia(
+        media_1.bulk_operation_annotatable_id = "bulk_id_1"
+        media_1.add_attribute(
+            hari_uploader.HARIAttribute(
+                id="attr_1",
+                name="my attribute 1",
+                attribute_type=models.AttributeType.Categorical,
+                value="value 1",
+                attribute_group=models.AttributeGroup.InitialAttribute,
+            )
+        )
+        self.uploader.add_media(media_1)
+        media_2 = hari_uploader.HARIMedia(
             name="my image 2",
+            media_type=models.MediaType.IMAGE,
+            back_reference="img_2",
+        )
+        media_2.bulk_operation_annotatable_id = "bulk_id_2"
+        media_2.add_attribute(
+            hari_uploader.HARIAttribute(
+                id="attr_1",
+                name="my attribute 2",
+                attribute_type=models.AttributeType.Categorical,
+                value="value 2",
+                attribute_group=models.AttributeGroup.InitialAttribute,
+            )
+        )
+        self.uploader.add_media(media_2)
+
+        # Act
+        self.uploader._update_hari_attribute_media_ids(
+            medias_to_upload=[media_1, media_2],
+            media_upload_bulk_response=models.BulkResponse(
+                results=[
+                    models.AnnotatableCreateResponse(
+                        item_id="new_media_id_1",
+                        back_reference="img_1",
+                        bulk_operation_annotatable_id="bulk_id_1",
+                        status=models.ResponseStatesEnum.SUCCESS,
+                    ),
+                    models.AnnotatableCreateResponse(
+                        item_id="new_media_id_2",
+                        back_reference="img_2",
+                        bulk_operation_annotatable_id="bulk_id_2",
+                        status=models.ResponseStatesEnum.SUCCESS,
+                    ),
+                ]
+            ),
+        )
+
+        # Assert
+        assert media_1.attributes[0].annotatable_id == "new_media_id_1"
+        assert media_1.attributes[0].annotatable_type == models.DataBaseObjectType.MEDIA
+        assert media_2.attributes[0].annotatable_id == "new_media_id_2"
+        assert media_2.attributes[0].annotatable_type == models.DataBaseObjectType.MEDIA
+        assert self.uploader._attribute_cnt == 2
+
+    def test_update_hari_attribute_media_object_ids(self):
+        # Arrange
+        media_1 = hari_uploader.HARIMedia(
+            name="my image 1",
             media_type=models.MediaType.IMAGE,
             back_reference="img_1",
         )
-    )
-
-    # Assert
-    assert log_spy.call_count == 1
-
-
-def test_warning_for_hari_uploader_receives_duplicate_media_object_back_reference(
-    mocker,
-):
-    # Arrange
-    log_spy = mocker.spy(hari_uploader.log, "warning")
-    uploader = hari_uploader.HARIUploader(
-        client=test_client, dataset_id=uuid.UUID(int=0)
-    )
-    media = hari_uploader.HARIMedia(
-        name="my image 1", media_type=models.MediaType.IMAGE, back_reference="img_1"
-    )
-    media.add_media_object(
-        hari_uploader.HARIMediaObject(
-            source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
-        )
-    )
-    media.add_media_object(
-        hari_uploader.HARIMediaObject(
-            source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
-        )
-    )
-
-    # Act
-    uploader.add_media(media)
-
-    # Assert
-    assert log_spy.call_count == 1
-
-
-def test_warning_for_media_without_back_reference(mocker):
-    # Arrange
-    log_spy = mocker.spy(hari_uploader.log, "warning")
-
-    # Act
-    hari_uploader.HARIMedia(
-        name="my image 1", media_type=models.MediaType.IMAGE, back_reference=""
-    )
-
-    # Assert
-    assert log_spy.call_count == 1
-
-
-def test_warning_for_media_object_without_back_reference(mocker):
-    # Arrange
-    log_spy = mocker.spy(hari_uploader.log, "warning")
-
-    # Act
-    hari_uploader.HARIMediaObject(source=models.DataSource.REFERENCE, back_reference="")
-
-    # Assert
-    assert log_spy.call_count == 1
-
-
-def test_hari_uploader_sets_bulk_operation_annotatable_id_automatically_on_medias(
-    mocker,
-):
-    # Arrange
-    # setup mock_client and mock_uploader that allow for testing the full upload method
-    mock_client = HARIClient(config=test_config)
-    mocker.patch.object(
-        mock_client,
-        "create_medias",
-        return_value=models.BulkResponse(
-            results=[
-                models.AnnotatableCreateResponse(
-                    status=models.ResponseStatesEnum.SUCCESS,
-                    item_id="server_side_media_id",
-                    bulk_operation_annotatable_id="bulk_id",
-                )
-            ]
-        ),
-    )
-    mocker.patch.object(
-        mock_client, "create_media_objects", return_value=models.BulkResponse()
-    )
-    pedestrian_subset_id = str(uuid.uuid4())
-    wheel_subset_id = str(uuid.uuid4())
-    object_categories = {"pedestrian", "wheel"}
-    object_category_vs_subsets = {
-        "pedestrian": pedestrian_subset_id,
-        "wheel": wheel_subset_id,
-    }
-    mocker.patch.object(
-        mock_client,
-        "create_subset",
-        side_effect=[pedestrian_subset_id, wheel_subset_id],
-    )
-    dataset_response = models.DatasetResponse(
-        id=uuid.UUID(int=0),
-        name="my dataset",
-        num_medias=1,
-        num_media_objects=1,
-        num_instances=1,
-        mediatype=models.MediaType.IMAGE,
-    )
-    mocker.patch.object(
-        mock_client,
-        "get_subsets_for_dataset",
-        side_effect=[
-            [dataset_response],
-        ],
-    )
-    mock_uploader = hari_uploader.HARIUploader(
-        client=mock_client,
-        dataset_id=uuid.UUID(int=0),
-        object_categories=object_categories,
-    )
-
-    def id_setter_mock(item: hari_uploader.HARIMedia | hari_uploader.HARIMediaObject):
-        item.bulk_operation_annotatable_id = "bulk_id"
-
-    mocker.patch.object(
-        mock_uploader, "_set_bulk_operation_annotatable_id", side_effect=id_setter_mock
-    )
-    id_setter_spy = mocker.spy(mock_uploader, "_set_bulk_operation_annotatable_id")
-
-    # 1 media with 1 media_object
-    media = hari_uploader.HARIMedia(
-        name="my image",
-        media_type=models.MediaType.IMAGE,
-        back_reference="img",
-    )
-    media.add_media_object(
-        hari_uploader.HARIMediaObject(
+        media_object_1 = hari_uploader.HARIMediaObject(
             source=models.DataSource.REFERENCE,
-            back_reference="img_obj",
+            back_reference="img_1_obj_1",
+            reference_data=models.BBox2DCenterPoint(
+                type=models.BBox2DType.BBOX2D_CENTER_POINT,
+                x=1400.0,
+                y=1806.0,
+                width=344.0,
+                height=732.0,
+            ),
         )
-    )
-    mock_uploader.add_media(media)
+        media_object_1.bulk_operation_annotatable_id = "bulk_id_1"
+        attribute_object_1 = hari_uploader.HARIAttribute(
+            id="attr_1",
+            name="Is human?",
+            attribute_type=models.AttributeType.Categorical,
+            value="yes",
+            attribute_group=models.AttributeGroup.InitialAttribute,
+        )
+        media_object_1.add_attribute(attribute_object_1)
+        media_1.add_media_object(media_object_1)
 
-    # Act
-    mock_uploader.upload()
+        media_2 = hari_uploader.HARIMedia(
+            name="my image 2",
+            media_type=models.MediaType.IMAGE,
+            back_reference="img_2",
+        )
+        media_object_2 = hari_uploader.HARIMediaObject(
+            source=models.DataSource.REFERENCE,
+            back_reference="img_2_obj_1",
+            reference_data=models.BBox2DCenterPoint(
+                type=models.BBox2DType.BBOX2D_CENTER_POINT,
+                x=1400.0,
+                y=1806.0,
+                width=344.0,
+                height=732.0,
+            ),
+        )
+        media_object_2.bulk_operation_annotatable_id = "bulk_id_2"
+        attribute_object_2 = hari_uploader.HARIAttribute(
+            id="attr_1",
+            name="Is human?",
+            attribute_type=models.AttributeType.Categorical,
+            value="yes",
+            attribute_group=models.AttributeGroup.InitialAttribute,
+        )
+        media_object_2.add_attribute(attribute_object_2)
+        media_2.add_media_object(media_object_2)
 
-    # Assert
-    # the bulk_operation_annotatable_id must be set on the media and media_object
-    assert id_setter_spy.call_count == 2
-    assert media.bulk_operation_annotatable_id == "bulk_id"
-    # it's ok that media and media object have the same bulk_id, because they're uploaded in separate batch operations
-    assert media.media_objects[0].bulk_operation_annotatable_id == "bulk_id"
-
-    # the media_id of the media_object must match the one provided by the create_medias
-    assert media.media_objects[0].media_id == "server_side_media_id"
-
-
-@pytest.mark.parametrize(
-    "bulk_responses, expected_merged_response",
-    [
-        ([], models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS)),
-        ([models.BulkResponse()], models.BulkResponse()),
-        (
-            [
-                models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS),
-                models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS),
-            ],
-            models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS),
-        ),
-        (
-            [
-                models.BulkResponse(
-                    status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
-                ),
-                models.BulkResponse(
-                    status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
-                ),
-            ],
-            models.BulkResponse(status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS),
-        ),
-        (
-            [
-                models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
-                models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
-            ],
-            models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
-        ),
-        (
-            [
-                models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
-                models.BulkResponse(
-                    status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
-                ),
-            ],
-            models.BulkResponse(status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS),
-        ),
-        (
-            [
-                models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
-                models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS),
-            ],
-            models.BulkResponse(status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS),
-        ),
-        (
-            [
-                models.BulkResponse(
-                    status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS,
-                    summary=models.BulkUploadSuccessSummary(
-                        total=5000, successful=4000, failed=1000
+        # Act
+        self.uploader._update_hari_attribute_media_object_ids(
+            media_objects_to_upload=[media_object_1, media_object_2],
+            media_object_upload_bulk_response=models.BulkResponse(
+                results=[
+                    models.AnnotatableCreateResponse(
+                        item_id="new_media_object_id_1",
+                        back_reference="img_1_obj_1",
+                        bulk_operation_annotatable_id="bulk_id_1",
+                        status=models.ResponseStatesEnum.SUCCESS,
                     ),
-                ),
-                models.BulkResponse(
-                    status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS,
-                    summary=models.BulkUploadSuccessSummary(
-                        total=3000, successful=1000, failed=2000
+                    models.AnnotatableCreateResponse(
+                        item_id="new_media_object_id_2",
+                        back_reference="img_2_obj_1",
+                        bulk_operation_annotatable_id="bulk_id_2",
+                        status=models.ResponseStatesEnum.SUCCESS,
                     ),
-                ),
+                ]
+            ),
+        )
+
+        # Assert
+        assert media_object_1.attributes[0].annotatable_id == "new_media_object_id_1"
+        assert (
+            media_object_1.attributes[0].annotatable_type
+            == models.DataBaseObjectType.MEDIAOBJECT
+        )
+        assert media_object_2.attributes[0].annotatable_id == "new_media_object_id_2"
+        assert (
+            media_object_2.attributes[0].annotatable_type
+            == models.DataBaseObjectType.MEDIAOBJECT
+        )
+
+    def test_hari_uploader_creates_batches_correctly(self, mocker):
+        # Arrange
+        # setup self.mock_client and mock_uploader that allow for testing the full upload method
+        mocker.patch.object(
+            self.mock_client,
+            "create_medias",
+            return_value=models.BulkResponse(
+                results=[
+                    models.AnnotatableCreateResponse(
+                        status=models.ResponseStatesEnum.SUCCESS,
+                        bulk_operation_annotatable_id=f"bulk_id_{i}",
+                    )
+                    for i in range(1100)
+                ]
+            ),
+        )
+        mocker.patch.object(
+            self.mock_client,
+            "create_media_objects",
+            return_value=models.BulkResponse(
+                results=[
+                    models.AnnotatableCreateResponse(
+                        status=models.ResponseStatesEnum.SUCCESS,
+                        bulk_operation_annotatable_id=f"bulk_id_{i}",
+                    )
+                    for i in range(2200)
+                ]
+            ),
+        )
+        mocker.patch.object(
+            self.mock_client, "create_attributes", return_value=models.BulkResponse()
+        )
+        pedestrian_subset_id = str(uuid.uuid4())
+        wheel_subset_id = str(uuid.uuid4())
+        object_categories = {"pedestrian", "wheel"}
+        object_category_vs_subsets = {
+            "pedestrian": pedestrian_subset_id,
+            "wheel": wheel_subset_id,
+        }
+        mocker.patch.object(
+            self.mock_client,
+            "create_subset",
+            side_effect=[pedestrian_subset_id, wheel_subset_id],
+        )
+        dataset_response = models.DatasetResponse(
+            id=uuid.UUID(int=0),
+            name="my dataset",
+            num_medias=1,
+            num_media_objects=1,
+            num_instances=1,
+            mediatype=models.MediaType.IMAGE,
+        )
+        mocker.patch.object(
+            self.mock_client,
+            "get_subsets_for_dataset",
+            side_effect=[
+                [dataset_response],
             ],
-            models.BulkResponse(
-                status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS,
-                summary=models.BulkUploadSuccessSummary(
-                    total=8000, successful=5000, failed=3000
+        )
+
+        # there are multiple batches of medias and media objects, but the bulk_ids for the medias are expected to be continuous
+        # as implemented in the create_medias mock above.
+        global running_media_bulk_id
+        running_media_bulk_id = 0
+        global running_media_object_bulk_id
+        running_media_object_bulk_id = 0
+
+        def id_setter_mock(
+            item: hari_uploader.HARIMedia | hari_uploader.HARIMediaObject,
+        ):
+            global running_media_bulk_id
+            global running_media_object_bulk_id
+            if isinstance(item, hari_uploader.HARIMedia):
+                item.bulk_operation_annotatable_id = f"bulk_id_{running_media_bulk_id}"
+                running_media_bulk_id += 1
+            elif isinstance(item, hari_uploader.HARIMediaObject):
+                item.bulk_operation_annotatable_id = (
+                    f"bulk_id_{running_media_object_bulk_id}"
+                )
+                running_media_object_bulk_id += 1
+
+        mock_uploader = hari_uploader.HARIUploader(
+            client=self.mock_client,
+            dataset_id=uuid.UUID(int=0),
+            object_categories=object_categories,
+        )
+        mocker.patch.object(
+            mock_uploader,
+            "_set_bulk_operation_annotatable_id",
+            side_effect=id_setter_mock,
+        )
+        media_spy = mocker.spy(mock_uploader, "_upload_media_batch")
+        media_object_spy = mocker.spy(mock_uploader, "_upload_media_object_batch")
+        attribute_spy = mocker.spy(mock_uploader, "_upload_attribute_batch")
+
+        # 1100 medias --> 3 batches
+        # 2200 media_objects --> 5 batches
+        # 6600 attributes --> 14 batches
+        for i in range(1100):
+            media = hari_uploader.HARIMedia(
+                name=f"my image {i}",
+                media_type=models.MediaType.IMAGE,
+                back_reference=f"img_{i}",
+            )
+            for k in range(2):
+                media_object = hari_uploader.HARIMediaObject(
+                    source=models.DataSource.REFERENCE,
+                    back_reference=f"img_{i}_obj_{k}",
+                )
+                media.add_media_object(media_object)
+                media.add_attribute(
+                    hari_uploader.HARIAttribute(
+                        id=f"attr_{i}_{k}",
+                        name=f"attr_{i}_{k}",
+                        attribute_type=models.AttributeType.Categorical,
+                        value=f"value_{i}_{k}",
+                        attribute_group=models.AttributeGroup.InitialAttribute,
+                    )
+                )
+                for l in range(2):
+                    media_object.add_attribute(
+                        hari_uploader.HARIAttribute(
+                            id=f"attr_{i}_{k}_{l}",
+                            name=f"attr_{i}_{k}_{l}",
+                            attribute_type=models.AttributeType.Categorical,
+                            value=f"value_{i}_{k}_{l}",
+                            attribute_group=models.AttributeGroup.InitialAttribute,
+                        )
+                    )
+            mock_uploader.add_media(media)
+
+        # Act
+        mock_uploader.upload()
+
+        # Assert
+        # check every batch upload method's call
+        assert media_spy.call_count == 3
+        media_calls = media_spy.call_args_list
+        assert len(media_calls[0].kwargs["medias_to_upload"]) == 500
+        assert len(media_calls[1].kwargs["medias_to_upload"]) == 500
+        assert len(media_calls[2].kwargs["medias_to_upload"]) == 100
+        assert len(mock_uploader._medias) == 1100
+
+        assert media_object_spy.call_count == 5
+        media_object_calls = media_object_spy.call_args_list
+        assert len(media_object_calls[0].kwargs["media_objects_to_upload"]) == 500
+        assert len(media_object_calls[1].kwargs["media_objects_to_upload"]) == 500
+        assert len(media_object_calls[2].kwargs["media_objects_to_upload"]) == 500
+        assert len(media_object_calls[3].kwargs["media_objects_to_upload"]) == 500
+        assert len(media_object_calls[4].kwargs["media_objects_to_upload"]) == 200
+        assert mock_uploader._media_object_cnt == 2200
+
+        assert attribute_spy.call_count == 14
+        attribute_calls = attribute_spy.call_args_list
+        assert len(attribute_calls[0].kwargs["attributes_to_upload"]) == 500
+        assert len(attribute_calls[1].kwargs["attributes_to_upload"]) == 500
+        assert len(attribute_calls[2].kwargs["attributes_to_upload"]) == 500
+        assert len(attribute_calls[3].kwargs["attributes_to_upload"]) == 500
+        assert len(attribute_calls[4].kwargs["attributes_to_upload"]) == 500
+        assert len(attribute_calls[5].kwargs["attributes_to_upload"]) == 500
+        assert len(attribute_calls[6].kwargs["attributes_to_upload"]) == 500
+        assert len(attribute_calls[7].kwargs["attributes_to_upload"]) == 500
+        assert len(attribute_calls[8].kwargs["attributes_to_upload"]) == 500
+        assert len(attribute_calls[9].kwargs["attributes_to_upload"]) == 500
+        assert len(attribute_calls[10].kwargs["attributes_to_upload"]) == 500
+        assert len(attribute_calls[11].kwargs["attributes_to_upload"]) == 500
+        assert len(attribute_calls[12].kwargs["attributes_to_upload"]) == 500
+        assert len(attribute_calls[13].kwargs["attributes_to_upload"]) == 100
+        assert mock_uploader._attribute_cnt == 6600
+
+    def test_hari_uploader_creates_single_batch_correctly(self, mocker):
+        # Arrange
+        # setup self.mock_client and mock_uploader that allow for testing the full upload method
+        mocker.patch.object(
+            self.mock_client,
+            "create_medias",
+            return_value=models.BulkResponse(
+                results=[
+                    models.AnnotatableCreateResponse(
+                        status=models.ResponseStatesEnum.SUCCESS,
+                        bulk_operation_annotatable_id=f"bulk_id_{i}",
+                    )
+                    for i in range(5)
+                ]
+            ),
+        )
+        mocker.patch.object(
+            self.mock_client,
+            "create_media_objects",
+            return_value=models.BulkResponse(
+                results=[
+                    models.AnnotatableCreateResponse(
+                        status=models.ResponseStatesEnum.SUCCESS,
+                        bulk_operation_annotatable_id=f"bulk_id_{i}",
+                    )
+                    for i in range(10)
+                ]
+            ),
+        )
+
+        mocker.patch.object(
+            self.mock_client, "create_attributes", return_value=models.BulkResponse()
+        )
+
+        pedestrian_subset_id = str(uuid.uuid4())
+        wheel_subset_id = str(uuid.uuid4())
+        object_categories = {"pedestrian", "wheel"}
+        object_category_vs_subsets = {
+            "pedestrian": pedestrian_subset_id,
+            "wheel": wheel_subset_id,
+        }
+        mocker.patch.object(
+            self.mock_client,
+            "create_subset",
+            side_effect=[pedestrian_subset_id, wheel_subset_id],
+        )
+        dataset_response = models.DatasetResponse(
+            id=uuid.UUID(int=0),
+            name="my dataset",
+            num_medias=1,
+            num_media_objects=1,
+            num_instances=1,
+            mediatype=models.MediaType.IMAGE,
+        )
+        mocker.patch.object(
+            self.mock_client,
+            "get_subsets_for_dataset",
+            side_effect=[
+                [dataset_response],
+            ],
+        )
+        mock_uploader = hari_uploader.HARIUploader(
+            client=self.mock_client,
+            dataset_id=uuid.UUID(int=0),
+            object_categories=object_categories,
+        )
+
+        global running_media_bulk_id
+        running_media_bulk_id = 0
+        global running_media_object_bulk_id
+        running_media_object_bulk_id = 0
+
+        def id_setter_mock(
+            item: hari_uploader.HARIMedia | hari_uploader.HARIMediaObject,
+        ):
+            global running_media_bulk_id
+            global running_media_object_bulk_id
+            if isinstance(item, hari_uploader.HARIMedia):
+                item.bulk_operation_annotatable_id = f"bulk_id_{running_media_bulk_id}"
+                running_media_bulk_id += 1
+            elif isinstance(item, hari_uploader.HARIMediaObject):
+                item.bulk_operation_annotatable_id = (
+                    f"bulk_id_{running_media_object_bulk_id}"
+                )
+                running_media_object_bulk_id += 1
+
+        mocker.patch.object(
+            mock_uploader,
+            "_set_bulk_operation_annotatable_id",
+            side_effect=id_setter_mock,
+        )
+        media_spy = mocker.spy(mock_uploader, "_upload_media_batch")
+        media_object_spy = mocker.spy(mock_uploader, "_upload_media_object_batch")
+        attribute_spy = mocker.spy(mock_uploader, "_upload_attribute_batch")
+
+        # 5 medias --> 1 batch
+        # 10 media_objects --> 1 batch
+        # 30 attributes --> 1 batch
+        for i in range(5):
+            media = hari_uploader.HARIMedia(
+                name=f"my image {i}",
+                media_type=models.MediaType.IMAGE,
+                back_reference=f"img_{i}",
+            )
+            for k in range(2):
+                media_object = hari_uploader.HARIMediaObject(
+                    source=models.DataSource.REFERENCE,
+                    back_reference=f"img_{i}_obj_{k}",
+                )
+                media.add_media_object(media_object)
+                media.add_attribute(
+                    hari_uploader.HARIAttribute(
+                        id=f"attr_{i}_{k}",
+                        name=f"attr_{i}_{k}",
+                        attribute_type=models.AttributeType.Categorical,
+                        value=f"value_{i}_{k}",
+                        attribute_group=models.AttributeGroup.InitialAttribute,
+                    )
+                )
+                for l in range(2):
+                    media_object.add_attribute(
+                        hari_uploader.HARIAttribute(
+                            id=f"attr_{i}_{k}_{l}",
+                            name=f"attr_{i}_{k}_{l}",
+                            attribute_type=models.AttributeType.Categorical,
+                            value=f"value_{i}_{k}_{l}",
+                            attribute_group=models.AttributeGroup.InitialAttribute,
+                        )
+                    )
+
+            mock_uploader.add_media(media)
+
+        # Act
+        mock_uploader.upload()
+
+        # Assert
+        # check every batch upload method's call
+        assert media_spy.call_count == 1
+        media_calls = media_spy.call_args_list
+        assert len(media_calls[0].kwargs["medias_to_upload"]) == 5
+        assert len(mock_uploader._medias) == 5
+
+        assert media_object_spy.call_count == 1
+        media_object_calls = media_object_spy.call_args_list
+        assert len(media_object_calls[0].kwargs["media_objects_to_upload"]) == 10
+        assert mock_uploader._media_object_cnt == 10
+
+        assert attribute_spy.call_count == 1
+        attribute_calls = attribute_spy.call_args_list
+        assert len(attribute_calls[0].kwargs["attributes_to_upload"]) == 30
+        assert mock_uploader._attribute_cnt == 30
+
+    def test_warning_for_hari_uploader_receives_duplicate_media_back_reference(
+        self, mocker
+    ):
+        # Arrange
+        log_spy = mocker.spy(hari_uploader.log, "warning")
+        self.uploader.add_media(
+            hari_uploader.HARIMedia(
+                name="my image 1",
+                media_type=models.MediaType.IMAGE,
+                back_reference="img_1",
+            )
+        )
+
+        # Act
+        self.uploader.add_media(
+            hari_uploader.HARIMedia(
+                name="my image 2",
+                media_type=models.MediaType.IMAGE,
+                back_reference="img_1",
+            )
+        )
+
+        # Assert
+        assert log_spy.call_count == 1
+
+    def test_warning_for_hari_uploader_receives_duplicate_media_object_back_reference(
+        self,
+        mocker,
+    ):
+        # Arrange
+        log_spy = mocker.spy(hari_uploader.log, "warning")
+        media = hari_uploader.HARIMedia(
+            name="my image 1", media_type=models.MediaType.IMAGE, back_reference="img_1"
+        )
+        media.add_media_object(
+            hari_uploader.HARIMediaObject(
+                source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
+            )
+        )
+        media.add_media_object(
+            hari_uploader.HARIMediaObject(
+                source=models.DataSource.REFERENCE, back_reference="img_1_obj_1"
+            )
+        )
+
+        # Act
+        self.uploader.add_media(media)
+
+        # Assert
+        assert log_spy.call_count == 1
+
+    def test_warning_for_media_without_back_reference(self, mocker):
+        # Arrange
+        log_spy = mocker.spy(hari_uploader.log, "warning")
+
+        # Act
+        hari_uploader.HARIMedia(
+            name="my image 1", media_type=models.MediaType.IMAGE, back_reference=""
+        )
+
+        # Assert
+        assert log_spy.call_count == 1
+
+    def test_warning_for_media_object_without_back_reference(self, mocker):
+        # Arrange
+        log_spy = mocker.spy(hari_uploader.log, "warning")
+
+        # Act
+        hari_uploader.HARIMediaObject(
+            source=models.DataSource.REFERENCE, back_reference=""
+        )
+
+        # Assert
+        assert log_spy.call_count == 1
+
+    def test_hari_uploader_sets_bulk_operation_annotatable_id_automatically_on_medias(
+        self,
+        mocker,
+    ):
+        # Arrange
+        mocker.patch.object(
+            self.mock_client,
+            "create_medias",
+            return_value=models.BulkResponse(
+                results=[
+                    models.AnnotatableCreateResponse(
+                        status=models.ResponseStatesEnum.SUCCESS,
+                        item_id="server_side_media_id",
+                        bulk_operation_annotatable_id="bulk_id",
+                    )
+                ]
+            ),
+        )
+        mocker.patch.object(
+            self.mock_client, "create_media_objects", return_value=models.BulkResponse()
+        )
+        pedestrian_subset_id = str(uuid.uuid4())
+        wheel_subset_id = str(uuid.uuid4())
+        object_categories = {"pedestrian", "wheel"}
+        object_category_vs_subsets = {
+            "pedestrian": pedestrian_subset_id,
+            "wheel": wheel_subset_id,
+        }
+        mocker.patch.object(
+            self.mock_client,
+            "create_subset",
+            side_effect=[pedestrian_subset_id, wheel_subset_id],
+        )
+        dataset_response = models.DatasetResponse(
+            id=uuid.UUID(int=0),
+            name="my dataset",
+            num_medias=1,
+            num_media_objects=1,
+            num_instances=1,
+            mediatype=models.MediaType.IMAGE,
+        )
+        mocker.patch.object(
+            self.mock_client,
+            "get_subsets_for_dataset",
+            side_effect=[
+                [dataset_response],
+            ],
+        )
+        mock_uploader = hari_uploader.HARIUploader(
+            client=self.mock_client,
+            dataset_id=uuid.UUID(int=0),
+            object_categories=object_categories,
+        )
+
+        def id_setter_mock(
+            item: hari_uploader.HARIMedia | hari_uploader.HARIMediaObject,
+        ):
+            item.bulk_operation_annotatable_id = "bulk_id"
+
+        mocker.patch.object(
+            mock_uploader,
+            "_set_bulk_operation_annotatable_id",
+            side_effect=id_setter_mock,
+        )
+        id_setter_spy = mocker.spy(mock_uploader, "_set_bulk_operation_annotatable_id")
+
+        # 1 media with 1 media_object
+        media = hari_uploader.HARIMedia(
+            name="my image",
+            media_type=models.MediaType.IMAGE,
+            back_reference="img",
+        )
+        media.add_media_object(
+            hari_uploader.HARIMediaObject(
+                source=models.DataSource.REFERENCE,
+                back_reference="img_obj",
+            )
+        )
+        mock_uploader.add_media(media)
+
+        # Act
+        mock_uploader.upload()
+
+        # Assert
+        # the bulk_operation_annotatable_id must be set on the media and media_object
+        assert id_setter_spy.call_count == 2
+        assert media.bulk_operation_annotatable_id == "bulk_id"
+        # it's ok that media and media object have the same bulk_id, because they're uploaded in separate batch operations
+        assert media.media_objects[0].bulk_operation_annotatable_id == "bulk_id"
+
+        # the media_id of the media_object must match the one provided by the create_medias
+        assert media.media_objects[0].media_id == "server_side_media_id"
+
+    @pytest.mark.parametrize(
+        "bulk_responses, expected_merged_response",
+        [
+            ([], models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS)),
+            ([models.BulkResponse()], models.BulkResponse()),
+            (
+                [
+                    models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS),
+                    models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS),
+                ],
+                models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS),
+            ),
+            (
+                [
+                    models.BulkResponse(
+                        status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
+                    ),
+                    models.BulkResponse(
+                        status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
+                    ),
+                ],
+                models.BulkResponse(
+                    status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
                 ),
             ),
-        ),
-        (
-            [
+            (
+                [
+                    models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
+                    models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
+                ],
+                models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
+            ),
+            (
+                [
+                    models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
+                    models.BulkResponse(
+                        status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
+                    ),
+                ],
+                models.BulkResponse(
+                    status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
+                ),
+            ),
+            (
+                [
+                    models.BulkResponse(status=models.BulkOperationStatusEnum.FAILURE),
+                    models.BulkResponse(status=models.BulkOperationStatusEnum.SUCCESS),
+                ],
+                models.BulkResponse(
+                    status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS
+                ),
+            ),
+            (
+                [
+                    models.BulkResponse(
+                        status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS,
+                        summary=models.BulkUploadSuccessSummary(
+                            total=5000, successful=4000, failed=1000
+                        ),
+                    ),
+                    models.BulkResponse(
+                        status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS,
+                        summary=models.BulkUploadSuccessSummary(
+                            total=3000, successful=1000, failed=2000
+                        ),
+                    ),
+                ],
+                models.BulkResponse(
+                    status=models.BulkOperationStatusEnum.PARTIAL_SUCCESS,
+                    summary=models.BulkUploadSuccessSummary(
+                        total=8000, successful=5000, failed=3000
+                    ),
+                ),
+            ),
+            (
+                [
+                    models.BulkResponse(
+                        results=[
+                            models.AnnotatableCreateResponse(
+                                item_id="1",
+                                status=models.ResponseStatesEnum.SUCCESS,
+                                back_reference="back_ref_1",
+                                bulk_operation_annotatable_id="bulk_id_1",
+                            ),
+                            models.AnnotatableCreateResponse(
+                                item_id="2",
+                                status=models.ResponseStatesEnum.SUCCESS,
+                                back_reference="back_ref_2",
+                                bulk_operation_annotatable_id="bulk_id_2",
+                            ),
+                        ]
+                    ),
+                    models.BulkResponse(
+                        results=[
+                            models.AnnotatableCreateResponse(
+                                item_id="3",
+                                status=models.ResponseStatesEnum.SUCCESS,
+                                back_reference="back_ref_3",
+                                bulk_operation_annotatable_id="bulk_id_3",
+                            ),
+                            models.AnnotatableCreateResponse(
+                                item_id="4",
+                                status=models.ResponseStatesEnum.SUCCESS,
+                                back_reference="back_ref_4",
+                                bulk_operation_annotatable_id="bulk_id_4",
+                            ),
+                        ]
+                    ),
+                ],
                 models.BulkResponse(
                     results=[
                         models.AnnotatableCreateResponse(
@@ -992,10 +1026,6 @@ def test_hari_uploader_sets_bulk_operation_annotatable_id_automatically_on_media
                             back_reference="back_ref_2",
                             bulk_operation_annotatable_id="bulk_id_2",
                         ),
-                    ]
-                ),
-                models.BulkResponse(
-                    results=[
                         models.AnnotatableCreateResponse(
                             item_id="3",
                             status=models.ResponseStatesEnum.SUCCESS,
@@ -1010,60 +1040,36 @@ def test_hari_uploader_sets_bulk_operation_annotatable_id_automatically_on_media
                         ),
                     ]
                 ),
-            ],
-            models.BulkResponse(
-                results=[
-                    models.AnnotatableCreateResponse(
-                        item_id="1",
-                        status=models.ResponseStatesEnum.SUCCESS,
-                        back_reference="back_ref_1",
-                        bulk_operation_annotatable_id="bulk_id_1",
-                    ),
-                    models.AnnotatableCreateResponse(
-                        item_id="2",
-                        status=models.ResponseStatesEnum.SUCCESS,
-                        back_reference="back_ref_2",
-                        bulk_operation_annotatable_id="bulk_id_2",
-                    ),
-                    models.AnnotatableCreateResponse(
-                        item_id="3",
-                        status=models.ResponseStatesEnum.SUCCESS,
-                        back_reference="back_ref_3",
-                        bulk_operation_annotatable_id="bulk_id_3",
-                    ),
-                    models.AnnotatableCreateResponse(
-                        item_id="4",
-                        status=models.ResponseStatesEnum.SUCCESS,
-                        back_reference="back_ref_4",
-                        bulk_operation_annotatable_id="bulk_id_4",
-                    ),
-                ]
             ),
-        ),
-    ],
-)
-def test_merge_bulk_responses(
-    bulk_responses: list[models.BulkResponse],
-    expected_merged_response: models.BulkResponse,
-):
-    actual_merged_response = hari_uploader._merge_bulk_responses(*bulk_responses)
-    assert actual_merged_response.status == expected_merged_response.status
-
-    assert (
-        actual_merged_response.summary.total == expected_merged_response.summary.total
+        ],
     )
-    assert (
-        actual_merged_response.summary.successful
-        == expected_merged_response.summary.successful
-    )
-    assert (
-        actual_merged_response.summary.failed == expected_merged_response.summary.failed
-    )
-
-    assert len(actual_merged_response.results) == len(expected_merged_response.results)
-    for actual_result, expected_result in zip(
-        actual_merged_response.results, expected_merged_response.results
+    def test_merge_bulk_responses(
+        self,
+        bulk_responses: list[models.BulkResponse],
+        expected_merged_response: models.BulkResponse,
     ):
-        assert actual_result.item_id == expected_result.item_id
-        assert actual_result.back_reference == expected_result.back_reference
-        assert actual_result.status == expected_result.status
+        actual_merged_response = hari_uploader._merge_bulk_responses(*bulk_responses)
+        assert actual_merged_response.status == expected_merged_response.status
+
+        assert (
+            actual_merged_response.summary.total
+            == expected_merged_response.summary.total
+        )
+        assert (
+            actual_merged_response.summary.successful
+            == expected_merged_response.summary.successful
+        )
+        assert (
+            actual_merged_response.summary.failed
+            == expected_merged_response.summary.failed
+        )
+
+        assert len(actual_merged_response.results) == len(
+            expected_merged_response.results
+        )
+        for actual_result, expected_result in zip(
+            actual_merged_response.results, expected_merged_response.results
+        ):
+            assert actual_result.item_id == expected_result.item_id
+            assert actual_result.back_reference == expected_result.back_reference
+            assert actual_result.status == expected_result.status

--- a/tests/test_hari_uploader.py
+++ b/tests/test_hari_uploader.py
@@ -62,7 +62,9 @@ def test_add_media(mock_uploader_for_object_category_validation):
     assert uploader._attribute_cnt == 1
 
 
-def test_create_object_category_subset(mock_uploader_for_object_category_validation):
+def test_create_object_category_subset_sets_uploader_attribute_correctly(
+    mock_uploader_for_object_category_validation,
+):
     (
         uploader,
         object_categories_vs_subsets,
@@ -123,7 +125,7 @@ def test_validate_media_objects_object_category_subsets_consistency(
     )
 
 
-def test_assign_media_objects_to_object_category_subsets(
+def test_assign_media_objects_to_object_category_subsets_sets_subset_ids_corectly(
     mock_uploader_for_object_category_validation,
 ):
     # Arrange

--- a/tests/test_hari_uploader.py
+++ b/tests/test_hari_uploader.py
@@ -17,6 +17,50 @@ test_config = Config(
 test_client = HARIClient(config=test_config)
 
 
+def test_add_media():
+    # Arrange
+    uploader = hari_uploader.HARIUploader(
+        client=test_client, dataset_id=uuid.UUID(int=0)
+    )
+    assert len(uploader._medias) == 0
+    assert uploader._attribute_cnt == 0
+
+    # Act
+    uploader.add_media(
+        hari_uploader.HARIMedia(
+            name="my image",
+            media_type=models.MediaType.IMAGE,
+            back_reference="img",
+            attributes=[
+                hari_uploader.HARIAttribute(
+                    id="attr_1",
+                    name="my attribute 1",
+                    attribute_type=models.AttributeType.Categorical,
+                    value="value 1",
+                    attribute_group=models.AttributeGroup.InitialAttribute,
+                )
+            ],
+        )
+    )
+
+    # Assert
+    assert len(uploader._medias) == 1
+    assert uploader._attribute_cnt == 1
+
+    # Act
+    # add another media without attributes
+    uploader.add_media(
+        hari_uploader.HARIMedia(
+            name="my image",
+            media_type=models.MediaType.IMAGE,
+            back_reference="img",
+        )
+    )
+    # Assert
+    assert len(uploader._medias) == 2
+    assert uploader._attribute_cnt == 1
+
+
 def test_update_hari_media_object_media_ids():
     # Arrange
     uploader = hari_uploader.HARIUploader(

--- a/tests/upload/fixtures.py
+++ b/tests/upload/fixtures.py
@@ -210,7 +210,7 @@ def mock_uploader_for_bulk_operation_annotatable_id_setter(test_client, mocker):
     return uploader, id_setter_spy
 
 
-def create_configurable_mock_uploader_successfull_single_batch(
+def create_configurable_mock_uploader_successful_single_batch(
     mocker,
     test_client,
     dataset_id: uuid.UUID,
@@ -227,7 +227,7 @@ def create_configurable_mock_uploader_successfull_single_batch(
     typing.Any,
     typing.Any,
 ]:
-    """Creates a configurable mock uploader for a successfull upload of a single batch of medias, media objects and attributes.
+    """Creates a configurable mock uploader for a successful upload of a single batch of medias, media objects and attributes.
         The number of medias, media objects and attributes can be configured, as well as the object categories and their corresponding
         subset_ids which are mocked to be created successfully.
         The first call to get_subsets_for_dataset will return an empty list, the second call will return the specified subsets.

--- a/tests/upload/fixtures.py
+++ b/tests/upload/fixtures.py
@@ -1,0 +1,301 @@
+import uuid
+
+import pytest
+
+from hari_client import hari_uploader
+from hari_client import HARIClient
+from hari_client import models
+
+
+@pytest.fixture()
+def mock_client(
+    test_client, mocker
+) -> tuple[hari_uploader.HARIUploader, HARIClient, dict[str, str]]:
+    """Sets up a basic uploader using object_categories
+    Mocks the create_subset method to return random subset ids in lexicographical order
+    returns
+        uploader: HARIUploader instance
+        object_category_vs_subsets: dict[str, str] mapping object category names to their subset ids
+    """
+
+    pedestrian_subset_id = str(uuid.uuid4())
+    wheel_subset_id = str(uuid.uuid4())
+    create_subset_return_val = [pedestrian_subset_id, wheel_subset_id]
+    mocker.patch.object(
+        test_client, "create_subset", side_effect=create_subset_return_val
+    )
+    yield test_client, create_subset_return_val
+
+
+@pytest.fixture()
+def mock_uploader_for_object_category_validation(mock_client):
+    client, create_subset_return_val = mock_client
+    object_categories = ["pedestrian", "wheel"]
+    uploader = hari_uploader.HARIUploader(
+        client=client,
+        dataset_id=uuid.UUID(int=0),
+        object_categories_to_validate=set(object_categories),
+    )
+
+    assert uploader.object_categories_to_validate == {
+        "pedestrian",
+        "wheel",
+    }
+    # lexigraphically sorted object categories vs subset ids
+    object_categories_vs_subset_ids = {
+        object_category_name: subset_id
+        for object_category_name, subset_id in zip(
+            object_categories, create_subset_return_val
+        )
+    }
+
+    assert uploader._object_category_subsets == {}
+    yield uploader, object_categories_vs_subset_ids
+
+
+@pytest.fixture()
+def mock_uploader_for_batching(test_client, mocker):
+    client = test_client
+
+    # setup mock_client and mock_uploader that allow for testing the full upload method
+    mocker.patch.object(
+        client,
+        "create_medias",
+        return_value=models.BulkResponse(
+            results=[
+                models.AnnotatableCreateResponse(
+                    status=models.ResponseStatesEnum.SUCCESS,
+                    bulk_operation_annotatable_id=f"bulk_id_{i}",
+                )
+                for i in range(1100)
+            ]
+        ),
+    )
+    mocker.patch.object(
+        client,
+        "create_media_objects",
+        return_value=models.BulkResponse(
+            results=[
+                models.AnnotatableCreateResponse(
+                    status=models.ResponseStatesEnum.SUCCESS,
+                    bulk_operation_annotatable_id=f"bulk_id_{i}",
+                )
+                for i in range(2200)
+            ]
+        ),
+    )
+    mocker.patch.object(client, "create_attributes", return_value=models.BulkResponse())
+    pedestrian_subset_id = str(uuid.uuid4())
+    wheel_subset_id = str(uuid.uuid4())
+    object_categories = {"pedestrian", "wheel"}
+
+    mocker.patch.object(
+        client,
+        "create_subset",
+        side_effect=[pedestrian_subset_id, wheel_subset_id],
+    )
+    dataset_response = models.DatasetResponse(
+        id=uuid.UUID(int=0),
+        name="my dataset",
+        num_medias=1,
+        num_media_objects=1,
+        num_instances=1,
+        mediatype=models.MediaType.IMAGE,
+    )
+    mocker.patch.object(
+        client,
+        "get_subsets_for_dataset",
+        side_effect=[
+            [dataset_response],
+        ],
+    )
+    uploader = hari_uploader.HARIUploader(
+        client=client,
+        dataset_id=uuid.UUID(int=0),
+    )
+
+    # there are multiple batches of medias and media objects, but the bulk_ids for the medias are expected to be continuous
+    # as implemented in the create_medias mock above.
+    global running_media_bulk_id
+    running_media_bulk_id = 0
+    global running_media_object_bulk_id
+    running_media_object_bulk_id = 0
+
+    def id_setter_mock(
+        item: hari_uploader.HARIMedia | hari_uploader.HARIMediaObject,
+    ):
+        global running_media_bulk_id
+        global running_media_object_bulk_id
+        if isinstance(item, hari_uploader.HARIMedia):
+            item.bulk_operation_annotatable_id = f"bulk_id_{running_media_bulk_id}"
+            running_media_bulk_id += 1
+        elif isinstance(item, hari_uploader.HARIMediaObject):
+            item.bulk_operation_annotatable_id = (
+                f"bulk_id_{running_media_object_bulk_id}"
+            )
+            running_media_object_bulk_id += 1
+
+    media_spy = mocker.spy(uploader, "_upload_media_batch")
+    media_object_spy = mocker.spy(uploader, "_upload_media_object_batch")
+    attribute_spy = mocker.spy(uploader, "_upload_attribute_batch")
+
+    mocker.patch.object(
+        uploader,
+        "_set_bulk_operation_annotatable_id",
+        side_effect=id_setter_mock,
+    )
+    yield uploader, media_spy, media_object_spy, attribute_spy
+
+
+@pytest.fixture()
+def mock_uploader_for_single_batch(test_client, mocker):
+    client = test_client
+
+    # setup mock_client and mock_uploader that allow for testing the full upload method
+    mocker.patch.object(
+        client,
+        "create_medias",
+        return_value=models.BulkResponse(
+            results=[
+                models.AnnotatableCreateResponse(
+                    status=models.ResponseStatesEnum.SUCCESS,
+                    bulk_operation_annotatable_id=f"bulk_id_{i}",
+                )
+                for i in range(5)
+            ]
+        ),
+    )
+    mocker.patch.object(
+        client,
+        "create_media_objects",
+        return_value=models.BulkResponse(
+            results=[
+                models.AnnotatableCreateResponse(
+                    status=models.ResponseStatesEnum.SUCCESS,
+                    bulk_operation_annotatable_id=f"bulk_id_{i}",
+                )
+                for i in range(10)
+            ]
+        ),
+    )
+
+    mocker.patch.object(client, "create_attributes", return_value=models.BulkResponse())
+
+    pedestrian_subset_id = str(uuid.uuid4())
+    wheel_subset_id = str(uuid.uuid4())
+    mocker.patch.object(
+        client,
+        "create_subset",
+        side_effect=[pedestrian_subset_id, wheel_subset_id],
+    )
+    dataset_response = models.DatasetResponse(
+        id=uuid.UUID(int=0),
+        name="my dataset",
+        num_medias=1,
+        num_media_objects=1,
+        num_instances=1,
+        mediatype=models.MediaType.IMAGE,
+    )
+    mocker.patch.object(
+        client,
+        "get_subsets_for_dataset",
+        side_effect=[
+            [dataset_response],
+        ],
+    )
+    uploader = hari_uploader.HARIUploader(
+        client=client,
+        dataset_id=uuid.UUID(int=0),
+    )
+
+    global running_media_bulk_id
+    running_media_bulk_id = 0
+    global running_media_object_bulk_id
+    running_media_object_bulk_id = 0
+
+    def id_setter_mock(
+        item: hari_uploader.HARIMedia | hari_uploader.HARIMediaObject,
+    ):
+        global running_media_bulk_id
+        global running_media_object_bulk_id
+        if isinstance(item, hari_uploader.HARIMedia):
+            item.bulk_operation_annotatable_id = f"bulk_id_{running_media_bulk_id}"
+            running_media_bulk_id += 1
+        elif isinstance(item, hari_uploader.HARIMediaObject):
+            item.bulk_operation_annotatable_id = (
+                f"bulk_id_{running_media_object_bulk_id}"
+            )
+            running_media_object_bulk_id += 1
+
+    mocker.patch.object(
+        uploader,
+        "_set_bulk_operation_annotatable_id",
+        side_effect=id_setter_mock,
+    )
+    media_spy = mocker.spy(uploader, "_upload_media_batch")
+    media_object_spy = mocker.spy(uploader, "_upload_media_object_batch")
+    attribute_spy = mocker.spy(uploader, "_upload_attribute_batch")
+
+    yield uploader, media_spy, media_object_spy, attribute_spy
+
+
+@pytest.fixture()
+def mock_uploader_for_bulk_operation_annotatable_id_setter(test_client, mocker):
+    client = test_client
+
+    mocker.patch.object(
+        client,
+        "create_medias",
+        return_value=models.BulkResponse(
+            results=[
+                models.AnnotatableCreateResponse(
+                    status=models.ResponseStatesEnum.SUCCESS,
+                    item_id="server_side_media_id",
+                    bulk_operation_annotatable_id="bulk_id",
+                )
+            ]
+        ),
+    )
+    mocker.patch.object(
+        client, "create_media_objects", return_value=models.BulkResponse()
+    )
+    pedestrian_subset_id = str(uuid.uuid4())
+    wheel_subset_id = str(uuid.uuid4())
+    mocker.patch.object(
+        client,
+        "create_subset",
+        side_effect=[pedestrian_subset_id, wheel_subset_id],
+    )
+    dataset_response = models.DatasetResponse(
+        id=uuid.UUID(int=0),
+        name="my dataset",
+        num_medias=1,
+        num_media_objects=1,
+        num_instances=1,
+        mediatype=models.MediaType.IMAGE,
+    )
+    mocker.patch.object(
+        client,
+        "get_subsets_for_dataset",
+        side_effect=[
+            [dataset_response],
+        ],
+    )
+    uploader = hari_uploader.HARIUploader(
+        client=client,
+        dataset_id=uuid.UUID(int=0),
+    )
+
+    def id_setter_mock(
+        item: hari_uploader.HARIMedia | hari_uploader.HARIMediaObject,
+    ):
+        item.bulk_operation_annotatable_id = "bulk_id"
+
+    mocker.patch.object(
+        uploader,
+        "_set_bulk_operation_annotatable_id",
+        side_effect=id_setter_mock,
+    )
+    id_setter_spy = mocker.spy(uploader, "_set_bulk_operation_annotatable_id")
+
+    return uploader, id_setter_spy


### PR DESCRIPTION
1648824166

# Description
 Users should be able to specify object categories and directly translate them into HARI as subsets.
This PR introduces this functionality


## Changes in this PR
- adds utility-methods to the `HariUploader` used by the `upload`-method
  - _create_object_category_subsets
  - _validate_media_objects_object_category_subsets_consistency
  - _assign_media_objects_to_object_category_subsets
- updates `quickstart.py`
- updates integration tests with object categories
- adds unit tests

# TODO
- [x] Sync with server for existing subsets