### PR TITLE
Restrict object_category field to UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - fixed merge_bulk_responses for the case when no responses are given, therefore uploading media without media_objects isn't identified as an unsuccessful upload anymore [PR#20](https://github.com/quality-match/hari-client/pull/20)
 - fixed bug updating media/annotatable ids for media objects and attributes when shared [PR#27](https://github.com/quality-match/hari-client/pull/27)
 
+### Breaking Changes
+
+- Object category field on MediaObjects enforced as UUID. [PR#29](https://github.com/quality-match/hari-client/pull/29)
+
 ### Internal
 
 - updated occurrences of old type-hinting conventions (e.g. using pipe (`|`) instead of `typing.Optional` and `typing.Union`) [PR#19](https://github.com/quality-match/hari-client/pull/19)

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import pathlib
 import types
 import typing
@@ -15,6 +16,13 @@ from hari_client.utils import logger
 T = typing.TypeVar("T")
 
 log = logger.setup_logger(__name__)
+
+
+class UUIDEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, uuid.UUID):
+            return str(obj)
+        return super().default(obj)
 
 
 def _parse_response_model(
@@ -158,6 +166,9 @@ class HARIClient:
         # prepare request
         self._refresh_access_token()
         full_url = f"{self.config.hari_api_base_url}{url}"
+
+        if "json" in kwargs:
+            kwargs["json"] = json.loads(json.dumps(kwargs["json"], cls=UUIDEncoder))
 
         # do request and basic error handling
         response = self.session.request(method, full_url, **kwargs)
@@ -1063,7 +1074,7 @@ class HARIClient:
         visualisations: list[models.VisualisationUnion] | None = None,
         subset_ids: list | None = None,
         instance_id: str | None = None,
-        object_category: str | None = None,
+        object_category: uuid.UUID | None = None,
         qm_data: list[models.GeometryUnion] | None = None,
         reference_data: models.GeometryUnion | None = None,
         frame_idx: int | None = None,
@@ -1157,7 +1168,7 @@ class HARIClient:
         media_id: str | None = None,
         instance_id: str | None = None,
         source: models.DataSource | None = None,
-        object_category: str | None = None,
+        object_category: uuid.UUID | None = None,
         qm_data: list[models.GeometryUnion] | None = None,
         reference_data: models.GeometryUnion | None = None,
         frame_idx: int | None = None,
@@ -1177,7 +1188,7 @@ class HARIClient:
             media_id: Media Id
             instance_id: Instance Id
             source: DataSource
-            object_category: Object Category
+            object_category: Object Categories subset id
             qm_data: QM sourced geometry object
             reference_data: Externally sourced geometry object
             frame_idx: Frame Idx

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -1188,7 +1188,7 @@ class HARIClient:
             media_id: Media Id
             instance_id: Instance Id
             source: DataSource
-            object_category: Object Categories subset id
+            object_category: Object category's subset id
             qm_data: QM sourced geometry object
             reference_data: Externally sourced geometry object
             frame_idx: Frame Idx

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -869,7 +869,7 @@ class MediaObjectCreate(BaseModel):
     subset_ids: set[str] | list[str] | None = None
 
     instance_id: str | None = None
-    object_category: str | None = None
+    object_category: uuid.UUID | None = None
     # source represents if the media object is either a geometry that was constructed by
     # QM, e.g., by annotating media data; or a geometry that was already provided by a
     # customer, and hence, would be a REFERENCE.


### PR DESCRIPTION
The hari API no longer allows the object_category to be arbitrary strings, but it rather has to be a UUID.

This PR adjusts the client to match this behavior and adds a custom JSONEncoder, that is able to serialize UUIDs.