### PR TITLE
Clean up of uuid vs str inconsistencies in current client api models

### DIFF
--- a/docs/example_code/quickstart.py
+++ b/docs/example_code/quickstart.py
@@ -41,7 +41,7 @@ media_object_1 = hari_uploader.HARIMediaObject(
         height=732.0,
     ),
 )
-attribute_object_1_id = str(uuid.uuid4())
+attribute_object_1_id = uuid.uuid4()
 attribute_object_1 = hari_uploader.HARIAttribute(
     id=attribute_object_1_id,
     name="Is this a human being?",
@@ -49,7 +49,7 @@ attribute_object_1 = hari_uploader.HARIAttribute(
     value=True,
 )
 
-attribute_media_1_id = str(uuid.uuid4())
+attribute_media_1_id = uuid.uuid4()
 attribute_media_1 = hari_uploader.HARIAttribute(
     id=attribute_media_1_id,
     name="area",

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -884,7 +884,7 @@ class BulkMediaObjectCreate(MediaObjectCreate):
 
 
 class AttributeCreate(BaseModel):
-    id: str
+    id: uuid.UUID
     name: str
     annotatable_id: str
     annotatable_type: typing.Literal[

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -187,10 +187,8 @@ class HARIUploader:
                 self._media_object_cnt += 1
                 self._attribute_cnt += len(media_object.attributes)
 
-    def _add_object_category_subset(
-        self, object_category: str, subset_id: uuid.UUID
-    ) -> None:
-        self._object_category_subsets[object_category] = str(subset_id)
+    def _add_object_category_subset(self, object_category: str, subset_id: str) -> None:
+        self._object_category_subsets[object_category] = subset_id
 
     def _create_object_category_subsets(self, object_categories: list[str]) -> None:
         log.info(f"Creating {len(object_categories)} object_category subsets.")

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -135,14 +135,15 @@ class HARIUploader:
                 HARIUploader will create a HARI subset for each object_category and add the corresponding medias and media_objects to it.
         """
         self.client: HARIClient = client
-        self.dataset_id: str = dataset_id
+        self.dataset_id: uuid.UUID = dataset_id
         self.object_categories = object_categories or set()
         self._medias: list[HARIMedia] = []
         self._media_back_references: set[str] = set()
         self._media_object_back_references: set[str] = set()
         self._media_object_cnt: int = 0
         self._attribute_cnt: int = 0
-        self._object_category_subsets: dict[str, uuid.UUID] = {}
+        # TODO: this should be a dict[str, uuid.UUID] as soon as the api models are updated
+        self._object_category_subsets: dict[str, str] = {}
 
     # TODO: add_media shouldn't do validation logic, because that expects that a specific order of operation is necessary,
     # specifically that means that media_objects and attributes have to be added to media before the media is added to the uploader.
@@ -186,7 +187,9 @@ class HARIUploader:
                 self._media_object_cnt += 1
                 self._attribute_cnt += len(media_object.attributes)
 
-    def _add_object_category_subset(self, object_category: str, subset_id: str) -> None:
+    def _add_object_category_subset(
+        self, object_category: str, subset_id: uuid.UUID
+    ) -> None:
         self._object_category_subsets[object_category] = str(subset_id)
 
     def _create_object_category_subsets(self, object_categories: list[str]) -> None:
@@ -248,10 +251,13 @@ class HARIUploader:
                 for media_object in media.media_objects:
                     # was the media_object assigned an object_category_subset_name?
                     if media_object.object_category_subset_name:
-                        media_object.object_category = (
+                        object_category_subset_id_str = (
                             self._object_category_subsets.get(
                                 media_object.object_category_subset_name
                             )
+                        )
+                        media_object.object_category = uuid.UUID(
+                            object_category_subset_id_str
                         )
                         # does a subset_id exist for the media_object's object_category_subset_name?
                         if media_object.object_category is None:
@@ -262,14 +268,16 @@ class HARIUploader:
                             )
                         # also add the object_category subset_id to the overall list of subset_ids
                         if media_object.subset_ids:
-                            media_object.subset_ids.append(media_object.object_category)
+                            media_object.subset_ids.append(
+                                object_category_subset_id_str
+                            )
                         else:
-                            media_object.subset_ids = [media_object.object_category]
+                            media_object.subset_ids = [object_category_subset_id_str]
                         # also add the object_category subset_id to the overall list of subset_ids for the media
                         if media.subset_ids:
-                            media.subset_ids.append(media_object.object_category)
+                            media.subset_ids.append(object_category_subset_id_str)
                         else:
-                            media.subset_ids = [media_object.object_category]
+                            media.subset_ids = [object_category_subset_id_str]
                         # avoid duplicates in the subset_ids list
                         media.subset_ids = list(set(media.subset_ids))
 

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -314,7 +314,7 @@ class HARIUploader:
         # add already existing subsets to the object_category_subsets dict
         for obj_category_subset in backend_object_category_subsets:
             self._add_object_category_subset(
-                obj_category_subset.name, obj_category_subset.id
+                obj_category_subset.name, str(obj_category_subset.id)
             )
 
         # check whether all required object_category subsets already exist

--- a/tests/test_hari_uploader.py
+++ b/tests/test_hari_uploader.py
@@ -725,7 +725,7 @@ def test_hari_uploader_upload_with_known_specified_object_categories(
     create_configurable_mock_uploader_successful_single_batch,
 ):
     # Arrange
-    create_subset_side_effect = [uuid.uuid4(), uuid.uuid4()]
+    create_subset_side_effect = [str(uuid.uuid4()), str(uuid.uuid4())]
     (
         uploader,
         _,
@@ -823,11 +823,11 @@ def test_hari_uploader_upload_with_already_existing_backend_category_subsets(
     create_configurable_mock_uploader_successful_single_batch,
 ):
     # Arrange
-    create_subset_side_effect = [uuid.uuid4(), uuid.uuid4()]
+    create_subset_side_effect = [str(uuid.uuid4()), str(uuid.uuid4())]
     get_subsets_for_dataset_side_effect = [
         [
             models.DatasetResponse(
-                id=subset_id,
+                id=uuid.UUID(subset_id),
                 name=subset_name,
                 object_category=True,
                 mediatype=models.MediaType.IMAGE,

--- a/tests/test_hari_uploader.py
+++ b/tests/test_hari_uploader.py
@@ -24,7 +24,7 @@ def test_add_media(mock_uploader_for_object_category_validation):
             back_reference="img",
             attributes=[
                 hari_uploader.HARIAttribute(
-                    id="attr_1",
+                    id=uuid.uuid4(),
                     name="my attribute 1",
                     attribute_type=models.AttributeType.Categorical,
                     value="value 1",
@@ -246,7 +246,7 @@ def test_update_hari_attribute_media_ids(mock_uploader_for_object_category_valid
     ) = mock_uploader_for_object_category_validation
 
     shared_attribute = hari_uploader.HARIAttribute(
-        id="attr_1",
+        id=uuid.uuid4(),
         name="my attribute 1",
         attribute_type=models.AttributeType.Categorical,
         value="value 1",
@@ -269,7 +269,7 @@ def test_update_hari_attribute_media_ids(mock_uploader_for_object_category_valid
     media_2.add_attribute(shared_attribute)
     media_2.add_attribute(
         hari_uploader.HARIAttribute(
-            id="attr_2",
+            id=uuid.uuid4(),
             name="my attribute 2",
             attribute_type=models.AttributeType.Categorical,
             value="value 2",
@@ -336,7 +336,7 @@ def test_update_hari_attribute_media_object_ids(
     )
     media_object_1.bulk_operation_annotatable_id = "bulk_id_1"
     shared_attribute_object_1 = hari_uploader.HARIAttribute(
-        id="attr_1",
+        id=uuid.uuid4(),
         name="Is human?",
         attribute_type=models.AttributeType.Categorical,
         value="yes",
@@ -363,7 +363,7 @@ def test_update_hari_attribute_media_object_ids(
     )
     media_object_2.bulk_operation_annotatable_id = "bulk_id_2"
     attribute_object_2 = hari_uploader.HARIAttribute(
-        id="attr_2",
+        id=uuid.uuid4(),
         name="Is human?",
         attribute_type=models.AttributeType.Categorical,
         value="yes",
@@ -434,7 +434,7 @@ def test_hari_uploader_creates_batches_correctly(mock_uploader_for_batching):
             media.add_media_object(media_object)
             media.add_attribute(
                 hari_uploader.HARIAttribute(
-                    id=f"attr_{i}_{k}",
+                    id=uuid.uuid4(),
                     name=f"attr_{i}_{k}",
                     attribute_type=models.AttributeType.Categorical,
                     value=f"value_{i}_{k}",
@@ -444,7 +444,7 @@ def test_hari_uploader_creates_batches_correctly(mock_uploader_for_batching):
             for l in range(2):
                 media_object.add_attribute(
                     hari_uploader.HARIAttribute(
-                        id=f"attr_{i}_{k}_{l}",
+                        id=uuid.uuid4(),
                         name=f"attr_{i}_{k}_{l}",
                         attribute_type=models.AttributeType.Categorical,
                         value=f"value_{i}_{k}_{l}",
@@ -528,7 +528,7 @@ def test_hari_uploader_creates_single_batch_correctly(
             media.add_media_object(media_object)
             media.add_attribute(
                 hari_uploader.HARIAttribute(
-                    id=f"attr_{i}_{k}",
+                    id=uuid.uuid4(),
                     name=f"attr_{i}_{k}",
                     attribute_type=models.AttributeType.Categorical,
                     value=f"value_{i}_{k}",
@@ -538,7 +538,7 @@ def test_hari_uploader_creates_single_batch_correctly(
             for l in range(2):
                 media_object.add_attribute(
                     hari_uploader.HARIAttribute(
-                        id=f"attr_{i}_{k}_{l}",
+                        id=uuid.uuid4(),
                         name=f"attr_{i}_{k}_{l}",
                         attribute_type=models.AttributeType.Categorical,
                         value=f"value_{i}_{k}_{l}",


### PR DESCRIPTION
1648824166

The inconsistencies weren't really a technical problem, because we now have the custom UUID serializer from #29, but there were pydantic warnings about it when running the quickstart script. They should be gone now with this update.