### PR TITLE
fix `HARIClient.create_attribute` method

### DIFF
--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -1716,7 +1716,7 @@ class HARIClient:
         return self._request(
             "POST",
             f"/datasets/{dataset_id}/attributes",
-            json=self._pack(locals(), ignore=["dataset_id"]),
+            json=self._pack(locals(), ignore=["dataset_id"], not_none=["question"]),
             success_response_item_model=models.Attribute,
         )
 


### PR DESCRIPTION
the question field gets special treatment in the backend, therefore it must be ignored by the client if it's None