### PR TITLE
Make use of empty subset creation endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [major.minor.patch] - DD-MM-YYYY
 
+## [2.0.1] - 24.10.2024
+
+- Updated create_subset endpoint used during object_category creation[PR#35](https://github.com/quality-match/hari-client/pull/35)
+
 ## [2.0.0] - 23.10.2024
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Minimum python version: **3.11**
 To install the hari-client package, use pip with the following command:
 
 ```bash
-python -m pip install "hari_client @ git+https://github.com/quality-match/hari-client@v2.0.0"
+python -m pip install "hari_client @ git+https://github.com/quality-match/hari-client@v2.0.1"
 ```
 
 ## Quickstart

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -562,7 +562,43 @@ class HARIClient:
             success_response_item_model=str,
         )
 
-    ### media ###
+    def create_empty_subset(
+        self,
+        dataset_id: uuid.UUID,
+        subset_type: models.SubsetType,
+        subset_name: str,
+        object_category: bool | None = False,
+        visibility_status: models.VisibilityStatus | None = None,
+    ) -> str:
+        """creates a new empty subset and uploads it to the database
+
+        Args:
+            dataset_id: Dataset Id
+            subset_type: Type of the subset (media, media_object, instance, attribute)
+            subset_name: The name of the subset
+            object_category: True if the new subset shall be shown as a category for objects in HARI
+            visibility_status: Visibility status of the created subset
+
+        Returns:
+            The new subset id
+
+        Raises:
+            APIException: If the request fails.
+        """
+        body = {}
+
+        return self._request(
+            "POST",
+            "/subsets",
+            params=self._pack(
+                locals(),
+            ),
+            json=body,
+            success_response_item_model=str,
+        )
+
+        ### media ###
+
     def create_media(
         self,
         dataset_id: uuid.UUID,

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -196,7 +196,7 @@ class HARIUploader:
         newly_created_object_category_subsets = {}
         # sort object_categories to ensure consistent subset creation order
         for object_category in sorted(object_categories):
-            subset_id = self.client.create_subset(
+            subset_id = self.client.create_empty_subset(
                 dataset_id=self.dataset_id,
                 subset_type=models.SubsetType.MEDIA_OBJECT,
                 subset_name=object_category,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="hari_client",
-    version="2.0.0",
+    version="2.0.1",
     description="A Python client for the HARI API",
     author="Quality Match GmbH",
     author_email="info@quality-match.com",

--- a/tests/upload/fixtures.py
+++ b/tests/upload/fixtures.py
@@ -23,7 +23,7 @@ def mock_client(
     wheel_subset_id = str(uuid.uuid4())
     create_subset_return_val = [pedestrian_subset_id, wheel_subset_id]
     mocker.patch.object(
-        test_client, "create_subset", side_effect=create_subset_return_val
+        test_client, "create_empty_subset", side_effect=create_subset_return_val
     )
     yield test_client, create_subset_return_val
 
@@ -92,7 +92,7 @@ def mock_uploader_for_batching(test_client, mocker):
 
     mocker.patch.object(
         client,
-        "create_subset",
+        "create_empty_subset",
         side_effect=[pedestrian_subset_id, wheel_subset_id],
     )
     dataset_response = models.DatasetResponse(
@@ -172,7 +172,7 @@ def mock_uploader_for_bulk_operation_annotatable_id_setter(test_client, mocker):
     wheel_subset_id = str(uuid.uuid4())
     mocker.patch.object(
         client,
-        "create_subset",
+        "create_empty_subset",
         side_effect=[pedestrian_subset_id, wheel_subset_id],
     )
     dataset_response = models.DatasetResponse(
@@ -293,7 +293,7 @@ def create_configurable_mock_uploader_successful_single_batch(mocker, test_clien
         if create_subset_side_effect is not None:
             mocker.patch.object(
                 test_client,
-                "create_subset",
+                "create_empty_subset",
                 side_effect=create_subset_side_effect,
             )
 
@@ -338,7 +338,7 @@ def create_configurable_mock_uploader_successful_single_batch(mocker, test_clien
         media_spy = mocker.spy(uploader, "_upload_media_batch")
         media_object_spy = mocker.spy(uploader, "_upload_media_object_batch")
         attribute_spy = mocker.spy(uploader, "_upload_attribute_batch")
-        subset_create_spy = mocker.spy(test_client, "create_subset")
+        subset_create_spy = mocker.spy(test_client, "create_empty_subset")
 
         return (
             uploader,


### PR DESCRIPTION
Hari has multiple endpoints for creating subsets.
The one we were using so far contains more logic and takes longer to execute. The extra logic is already covered in metadata_rebuild, which is necessary to be called, anways.

