### PR TITLE
Serialize datetime objects to iso 8601 strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [major.minor.patch] - DD-MM-YYYY
 
+## [2.0.3] - 07.11.2024
+
+### Fixes
+
+- added support for serialization of `datetime` objects to the HARIClient. They're serialized to ISO-8601 strings now. [PR#38](https://github.com/quality-match/hari-client/pull/38)
+
 ## [2.0.2] - 30.10.2024
 
 ### Internal

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Minimum python version: **3.11**
 To install the hari-client package, use pip with the following command:
 
 ```bash
-python -m pip install "hari_client @ git+https://github.com/quality-match/hari-client@v2.0.2"
+python -m pip install "hari_client @ git+https://github.com/quality-match/hari-client@v2.0.3"
 ```
 
 ## Quickstart

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -18,10 +18,12 @@ T = typing.TypeVar("T")
 log = logger.setup_logger(__name__)
 
 
-class UUIDEncoder(json.JSONEncoder):
+class CustomJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, uuid.UUID):
             return str(obj)
+        elif isinstance(obj, datetime.datetime):
+            return obj.isoformat()
         return super().default(obj)
 
 
@@ -168,7 +170,9 @@ class HARIClient:
         full_url = f"{self.config.hari_api_base_url}{url}"
 
         if "json" in kwargs:
-            kwargs["json"] = json.loads(json.dumps(kwargs["json"], cls=UUIDEncoder))
+            kwargs["json"] = json.loads(
+                json.dumps(kwargs["json"], cls=CustomJSONEncoder)
+            )
 
         # do request and basic error handling
         response = self.session.request(method, full_url, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="hari_client",
-    version="2.0.2",
+    version="2.0.3",
     description="A Python client for the HARI API",
     author="Quality Match GmbH",
     author_email="info@quality-match.com",


### PR DESCRIPTION
1614747154

Without this fix the serialization of datetime objects fails, because it's not handled automatically.