### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [major.minor.patch] - DD-MM-YYYY
 
-### New Features
+### [2.1.0] - 2024-11-26
 
 - added support for `anonymize` and `calculate_histograms` parameters to `trigger_metadata_rebuild_job` and `trigger_dataset_metadata_rebuild_job`
 - added support for `force_recreate` flag for these methods:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Minimum python version: **3.11**
 To install the hari-client package, use pip with the following command:
 
 ```bash
-python -m pip install "hari_client @ git+https://github.com/quality-match/hari-client@v2.0.3"
+python -m pip install "hari_client @ git+https://github.com/quality-match/hari-client@v2.1.0"
 ```
 
 ## Quickstart

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="hari_client",
-    version="2.0.3",
+    version="2.1.0",
     description="A Python client for the HARI API",
     author="Quality Match GmbH",
     author_email="info@quality-match.com",


### PR DESCRIPTION
Release 2.1.0

### [2.1.0] - 2024-11-26

- added support for `anonymize` and `calculate_histograms` parameters to `trigger_metadata_rebuild_job` and `trigger_dataset_metadata_rebuild_job`
- added support for `force_recreate` flag for these methods:
  - `trigger_crops_creation_job`
  - `trigger_thumbnails_creation_job`
  - `trigger_dataset_metadata_rebuild_job`
  - `trigger_metadata_rebuild_job`