### PR TITLE
Add repeats, possible values and cant solve ratio to all attribute models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [major.minor.patch] - DD-MM-YYYY
 
+### Breaking Changes
+
+- added repeats and possible values to all attribute models.
+  - these fields, as well as frequency and can't solves are required for annotation attributes of type Binary and Categorical. [PR#47](https://github.com/quality-match/hari-client/pull/47)
+
 ## [2.1.0] - 11.11.2024
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [major.minor.patch] - DD-MM-YYYY
 
+### New Features
+- added cant solve ratio to all attribute models. [PR#47](https://github.com/quality-match/hari-client/pull/47)
+
 ### Breaking Changes
 
 - added repeats and possible values to all attribute models.

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -989,6 +989,7 @@ class Attribute(BaseModel):
     question: str | None = None
     ml_predictions: dict[str, float] | None = None
     ml_probability_distributions: dict[str, float] | None = None
+    cant_solve_ratio: float | None = None
     repeats: int | None = None
     possible_values: list[str | int | float | bool] | None = None
 
@@ -1047,6 +1048,10 @@ class AttributeResponse(BaseModel):
         description="A point estimate for the probability associated with each category"
         ", obtained from the full Dirichlet distribution predicted by the"
         " model.",
+    )
+    cant_solve_ratio: float | None = pydantic.Field(
+        default=None,
+        title="Can't Solve Ratio",
     )
     repeats: int | None = pydantic.Field(
         default=None,

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -945,6 +945,8 @@ class AttributeCreate(BaseModel):
     cumulated_frequency: typing.Any | None = None
     frequency: dict[str, int] | None = None
     question: str | None = None
+    repeats: int | None = None
+    possible_values: list[str | int | float | bool] | None = None
 
     @pydantic.model_validator(mode="before")
     @classmethod
@@ -987,6 +989,8 @@ class Attribute(BaseModel):
     question: str | None = None
     ml_predictions: dict[str, float] | None = None
     ml_probability_distributions: dict[str, float] | None = None
+    repeats: int | None = None
+    possible_values: list[str | int | float | bool] | None = None
 
 
 class AttributeResponse(BaseModel):
@@ -1043,6 +1047,16 @@ class AttributeResponse(BaseModel):
         description="A point estimate for the probability associated with each category"
         ", obtained from the full Dirichlet distribution predicted by the"
         " model.",
+    )
+    repeats: int | None = pydantic.Field(
+        default=None,
+        title="Repeats",
+        description="Number of repeats for this attribute",
+    )
+    possible_values: list[str | int | float | bool] | None = pydantic.Field(
+        default=None,
+        title="Possible Values",
+        description="Possible values for this attribute",
     )
 
 


### PR DESCRIPTION
Add repeats and possible values, as well as cant solve ration, to all attribute models