### PR TITLE
Fix query arg serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 ## [3.0.0] - 06.12.2024
 
 ### New Features
+
 - added cant solve ratio to all attribute models. [PR#47](https://github.com/quality-match/hari-client/pull/47)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Fixes
 
 - correct typo in development installation guidelines [PR#43](https://github.com/quality-match/hari-client/pull/43)
-- `query` argument of multiple methods is now serialized properly to fit the backend's implementation of a query parameter array [PR#49](https://github.com/quality-match/hari-client/pull/47)
+- `query` argument of multiple methods is now serialized properly to fit the backend's implementation of a query parameter array [PR#49](https://github.com/quality-match/hari-client/pull/49)
   - get_medias
   - get_media_count
   - get_media_objects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
 ### Fixes
 
 - correct typo in development installation guidelines [PR#43](https://github.com/quality-match/hari-client/pull/43)
+- `query` argument of multiple methods is now serialized properly to fit the fastapi expection of a query parameter array [PR#49](https://github.com/quality-match/hari-client/pull/47)
+  - get_medias
+  - get_media_count
+  - get_media_objects
+  - get_media_object_count
+  - get_attributes
+  - get_attribute_metadata
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Fixes
 
 - correct typo in development installation guidelines [PR#43](https://github.com/quality-match/hari-client/pull/43)
-- `query` argument of multiple methods is now serialized properly to fit the fastapi expection of a query parameter array [PR#49](https://github.com/quality-match/hari-client/pull/47)
+- `query` argument of multiple methods is now serialized properly to fit the backend's implementation of a query parameter array [PR#49](https://github.com/quality-match/hari-client/pull/47)
   - get_medias
   - get_media_count
   - get_media_objects

--- a/docs/example_code/quickstart.py
+++ b/docs/example_code/quickstart.py
@@ -44,15 +44,15 @@ media_object_1 = hari_uploader.HARIMediaObject(
 attribute_object_1_id = uuid.uuid4()
 attribute_object_1 = hari_uploader.HARIAttribute(
     id=attribute_object_1_id,
-    name="Is this a human being?",
+    name="is_walking",
     value=True,
 )
 
 attribute_media_1_id = uuid.uuid4()
 attribute_media_1 = hari_uploader.HARIAttribute(
     id=attribute_media_1_id,
-    name="area",
-    value=6912,
+    name="weather_condition",
+    value="sunny",
 )
 media_1.add_attribute(attribute_media_1)
 media_object_1.add_attribute(attribute_object_1)

--- a/docs/example_code/quickstart.py
+++ b/docs/example_code/quickstart.py
@@ -45,7 +45,6 @@ attribute_object_1_id = uuid.uuid4()
 attribute_object_1 = hari_uploader.HARIAttribute(
     id=attribute_object_1_id,
     name="Is this a human being?",
-    attribute_type=models.AttributeType.Binary,
     value=True,
 )
 
@@ -53,7 +52,6 @@ attribute_media_1_id = uuid.uuid4()
 attribute_media_1 = hari_uploader.HARIAttribute(
     id=attribute_media_1_id,
     name="area",
-    attribute_type=models.AttributeType.Categorical,
     value=6912,
 )
 media_1.add_attribute(attribute_media_1)

--- a/docs/example_code/upload_new_data_to_existing_dataset/upload_new_data_to_existing_dataset.py
+++ b/docs/example_code/upload_new_data_to_existing_dataset/upload_new_data_to_existing_dataset.py
@@ -129,14 +129,14 @@ new_media_object.set_object_category_subset_name("my_new_object_category")
 object_categories = {"my_new_object_category"}
 
 # Add an already known initial attribute to the media and media object.
-# In the example case we know that the existing media attribute value type is number.
+# In the example case we know that the existing media attribute value type is string.
 existing_media_attribute = list(media_attribute_lookup.values())[0]
 new_media.add_attribute(
     hari_uploader.HARIAttribute(
         id=existing_media_attribute.id,
         name=existing_media_attribute.name,
         attribute_type=existing_media_attribute.attribute_type,
-        value=500,
+        value="sunny",
     )
 )
 

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -2073,6 +2073,11 @@ class HARIClient:
     def get_visualisation_configs(
         self,
         dataset_id: uuid.UUID,
+        archived: bool | None = False,
+        query: models.QueryList | None = None,
+        sort: list[models.SortingParameter] | None = None,
+        limit: int | None = None,
+        skip: int | None = None,
     ) -> list[models.VisualisationConfiguration]:
         """
         Retrieve the visualization configurations for a given dataset.

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -141,9 +141,10 @@ def handle_union_parsing(item, union_type):
 def _serialize_query_list_for_request(
     query: models.QueryList | list[str] | str | None,
 ) -> list[str] | None:
-    """Serialize a QueryList to a list of strings that can be used as a list query parameter in the HARIClient::_request method.
-    In the future only a QueryList should be supported, but due to existing workarounds, this method also supports those workarounds.
-    You can pass a single already serialized QueryParameter and LogicParameter object (serialized with json.dumps), or a list of them.
+    """Serializes a variable of type QueryList to a list[str]. This list can be passed to the HARIClient::_request method as a query parameter and it will handle
+    formatting it as a query parameter array.
+    Note that in the future only QueryList will be supported. For now other types are supported due to existing workarounds.
+    The workarounds are: passing a single already serialized QueryParameter/LogicParameter object (serialized with json.dumps), or a list of them.
 
     Args:
         query: The QueryList to serialize

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -141,7 +141,7 @@ def handle_union_parsing(item, union_type):
 def _prepare_request_query_params(
     params: dict[str, typing.Any]
 ) -> dict[str, typing.Any]:
-    """Prepares query parameters for the request modules `request` method.
+    """Prepares query parameters for the request module's `request` method.
     Handled cases:
       - parameter value is a list of pydantic models.
         - Serializes a query param value of type list[pydantic.BaseModel] to a list[str]. Lists are formatted by the `request` method as `?my_list=value_1&my_list=value_2&my_list=value_3...`,

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -2084,6 +2084,11 @@ class HARIClient:
 
         Args:
             dataset_id (UUID): The ID of the dataset for which to retrieve visualization configurations.
+            archived: Whether to include archived VisualisationConfigs (default: False)
+            query: The filters to be applied to the search
+            sort: The list of sorting parameters
+            limit: How many visualisation_configs to return
+            skip: How many visualisation_configs to skip
 
         Returns:
             list[models.VisualisationConfiguration]: A list of visualization configuration objects.
@@ -2091,5 +2096,6 @@ class HARIClient:
         return self._request(
             method="GET",
             path=f"/datasets/{dataset_id}/visualisationConfigs",
+            params=self._pack(locals(), ignore=["dataset_id"]),
             success_response_item_model=list[models.VisualisationConfiguration],
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -257,6 +257,8 @@ def test_trigger_metadata_rebuild_validation_for_dataset_ids_list(test_client):
 @pytest.mark.parametrize(
     "query, expected",
     [
+        # None stays None
+        (None, None),
         # single stringified QueryParameter
         (
             json.dumps(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -259,6 +259,25 @@ def test_trigger_metadata_rebuild_validation_for_dataset_ids_list(test_client):
     [
         # None stays None
         ({"query": None, "other": None}, {"query": None, "other": None}),
+        # multiple typical query parameters (not related to QueryList)
+        (
+            {
+                "limit": 100,
+                "offset": 5.45,
+                "with_filter": True,
+                "id": "abcd-0123",
+                "my_none": None,
+                "my_list": [0, 1, 2, "three", 4.5, None, False, True],
+            },
+            {
+                "limit": 100,
+                "offset": 5.45,
+                "with_filter": True,
+                "id": "abcd-0123",
+                "my_none": None,
+                "my_list": [0, 1, 2, "three", 4.5, None, False, True],
+            },
+        ),
         # single stringified QueryParameter
         (
             {


### PR DESCRIPTION
1721653103

The `query` argument wasn't serialized properly for multiple methods.
This is now fixed. Support for existing workarounds, where the query argument was passed as an already stringified single QueryParameter oder LogicParameter object or as a list of those is kept, but will be removed in the future. If you've already used this workaround, please update your scripts.