### PR TITLE
add validations for initial attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   - media
   - media object
   - attributes
+- added attribute validations to hari_uploader [PR#55](https://github.com/quality-match/hari-client/pull/55)
+  - attribute value types have to be consistent
+  - attributes with a list as value have to have a single consistent value type for their list elements
+  - attributes with the same name and annotatable_type have to reuse the same attribute id
 
 ### Fixes
 

--- a/hari_client/__init__.py
+++ b/hari_client/__init__.py
@@ -3,6 +3,15 @@ from hari_client.client.client import HARIClient
 from hari_client.config.config import Config
 from hari_client.config.config import HARIUploaderConfig
 from hari_client.models import models
+from hari_client.models import validation
 from hari_client.upload import hari_uploader
 
-__all__ = [HARIClient, Config, errors, models, hari_uploader, HARIUploaderConfig]
+__all__ = [
+    HARIClient,
+    Config,
+    errors,
+    models,
+    validation,
+    hari_uploader,
+    HARIUploaderConfig,
+]

--- a/hari_client/client/errors.py
+++ b/hari_client/client/errors.py
@@ -102,7 +102,7 @@ class AttributeValidationInconsistentValueTypeError(Exception):
     ):
         message = (
             f"Found multiple value types {found_value_types} for attribute {attribute_name} with {annotatable_type=}."
-            + " Make sure every attribute with the same name and attribute type has the same value type."
+            + " Make sure every attribute with the same name and annotatable type has the same value type."
         )
         super().__init__(message)
 

--- a/hari_client/client/errors.py
+++ b/hari_client/client/errors.py
@@ -137,6 +137,6 @@ class AttributeValidationIdNotReusedError(Exception):
     ):
         message = (
             f"Found multiple ids {found_ids} for the same attribute name {attribute_name} with {annotatable_type=}."
-            + " Make sure every attribute with the same name and attribute type is using the same id."
+            + " Make sure every attribute with the same name and annotatable type is using the same id."
         )
         super().__init__(message)

--- a/hari_client/client/errors.py
+++ b/hari_client/client/errors.py
@@ -118,6 +118,19 @@ class AttributeValidationInconsistentListElementValueTypesError(Exception):
         super().__init__(message)
 
 
+class AttributeValidationInconsistentListElementValueTypesMultipleAttributesError(
+    Exception
+):
+    def __init__(
+        self, attribute_name: str, annotatable_type: str, found_value_types: list[str]
+    ):
+        message = (
+            f"Found multiple instances of attribute {attribute_name} with {annotatable_type=} with inconsistent list element value types {found_value_types}."
+            + " Make sure every instance of this attribute uses the same list element value types."
+        )
+        super().__init__(message)
+
+
 class AttributeValidationIdNotReusedError(Exception):
     def __init__(
         self, attribute_name: str, annotatable_type: str, found_ids: list[str]

--- a/hari_client/client/errors.py
+++ b/hari_client/client/errors.py
@@ -94,3 +94,36 @@ class BulkOperationAnnotatableIdMissing(Exception):
             "Its value should be a unique UUID for each item within the bulk."
         )
         super().__init__(message)
+
+
+class AttributeValidationInconsistentValueTypeError(Exception):
+    def __init__(
+        self, attribute_name: str, annotatable_type: str, found_value_types: list[str]
+    ):
+        message = (
+            f"Found multiple value types {found_value_types} for attribute {attribute_name} with {annotatable_type=}."
+            + " Make sure every attribute with the same name and attribute type has the same value type."
+        )
+        super().__init__(message)
+
+
+class AttributeValidationInconsistentListElementValueTypesError(Exception):
+    def __init__(
+        self, attribute_name: str, annotatable_type: str, found_value_types: list[str]
+    ):
+        message = (
+            f"Found multiple list element value types {found_value_types} for attribute {attribute_name} with {annotatable_type=}."
+            + " Make sure every list element has the same value type."
+        )
+        super().__init__(message)
+
+
+class AttributeValidationIdNotReusedError(Exception):
+    def __init__(
+        self, attribute_name: str, annotatable_type: str, found_ids: list[str]
+    ):
+        message = (
+            f"Found multiple ids {found_ids} for the same attribute name {attribute_name} with {annotatable_type=}."
+            + " Make sure every attribute with the same name and attribute type is using the same id."
+        )
+        super().__init__(message)

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -586,9 +586,13 @@ class VisualisationConfiguration(BaseModel):
     timestamp: str = pydantic.Field(default=None, title="Timestamp")
     archived: bool | None = pydantic.Field(default=False, title="Archived")
     name: str = pydantic.Field(title="Name")
-    parameters: CropVisualisationConfigParameters | LidarVideoVisualisationConfigParameters | LidarVideoStackedVisualisationConfigParameters | TileVisualisationConfigParameters | RenderedVisualisationConfigParameters = pydantic.Field(
-        title="CropVisualisationConfigParameters"
-    )
+    parameters: (
+        CropVisualisationConfigParameters
+        | LidarVideoVisualisationConfigParameters
+        | LidarVideoStackedVisualisationConfigParameters
+        | TileVisualisationConfigParameters
+        | RenderedVisualisationConfigParameters
+    ) = pydantic.Field(title="CropVisualisationConfigParameters")
     subset_ids: list = pydantic.Field(title="Subset Ids")
 
 

--- a/hari_client/models/validation/__init__.py
+++ b/hari_client/models/validation/__init__.py
@@ -1,5 +1,5 @@
 from hari_client.models.validation.attribute_validation import (
-    validate_initial_attributes,
+    validate_attributes,
 )
 
-__all__ = [validate_initial_attributes]
+__all__ = [validate_attributes]

--- a/hari_client/models/validation/__init__.py
+++ b/hari_client/models/validation/__init__.py
@@ -1,0 +1,5 @@
+from hari_client.models.validation.attribute_validation import (
+    validate_initial_attributes,
+)
+
+__all__ = [validate_initial_attributes]

--- a/hari_client/models/validation/attribute_validation.py
+++ b/hari_client/models/validation/attribute_validation.py
@@ -1,0 +1,91 @@
+import numbers
+import typing
+
+from hari_client import errors
+from hari_client import models
+
+
+def validate_initial_attributes(
+    attributes: list[models.AttributeCreate],
+) -> None:
+    """Raises an error if any requirements for initial attributes aren't met.
+    Attribute requirements:
+    - attributes with the same name and annotatable type must
+        - have the same value type
+        - have the same id
+    - attributes with value type list, mustn't contain multiple value types in the list
+
+    Args:
+        attributes: List of attributes to validate.
+
+    Raises:
+        AttributeValidationInconsistentValueTypeError: If the value type for an attribute is inconsistent.
+        AttributeValidationInconsistentListElementValueTypesError: If the elements in a list attribute value have mixed value types.
+        AttributeValidationIdNotReusedError: If another attribute with the same name and attribute type has a different id.
+    """
+    grouped_by_attribute_type: dict[str, list[models.AttributeCreate]] = {
+        models.DataBaseObjectType.MEDIA: [],
+        models.DataBaseObjectType.MEDIAOBJECT: [],
+        models.DataBaseObjectType.INSTANCE: [],
+    }
+    for attribute in attributes:
+        grouped_by_attribute_type[attribute.annotatable_type].append(attribute)
+
+    for (
+        annotatable_type,
+        attributes_with_same_annotatable_type,
+    ) in grouped_by_attribute_type.items():
+        name_value_type_map: dict[str, str] = {}
+        name_id_map: dict[str, str] = {}
+
+        for attribute in attributes_with_same_annotatable_type:
+            # check value type
+            value_type = _get_value_type_for_comparison(attribute.value)
+            if attribute.name in name_value_type_map:
+                if name_value_type_map[attribute.name] != value_type:
+                    raise errors.AttributeValidationInconsistentValueTypeError(
+                        attribute_name=attribute.name,
+                        annotatable_type=annotatable_type,
+                        found_value_types=[
+                            name_value_type_map[attribute.name],
+                            value_type,
+                        ],
+                    )
+            else:
+                name_value_type_map[attribute.name] = value_type
+
+            # check list elements if value type is list
+            if value_type == "list":
+                found_list_element_value_types: set[str] = set()
+                for element in attribute.value:
+                    found_list_element_value_types.add(
+                        _get_value_type_for_comparison(element)
+                    )
+                if len(found_list_element_value_types) > 1:
+                    raise errors.AttributeValidationInconsistentListElementValueTypesError(
+                        attribute_name=attribute.name,
+                        annotatable_type=annotatable_type,
+                        found_value_types=found_list_element_value_types,
+                    )
+
+            # check id
+            if attribute.name in name_id_map:
+                if name_id_map[attribute.name] != str(attribute.id):
+                    raise errors.AttributeValidationIdNotReusedError(
+                        attribute_name=attribute.name,
+                        annotatable_type=annotatable_type,
+                        found_ids=[
+                            name_id_map[attribute.name],
+                            str(attribute.id),
+                        ],
+                    )
+            else:
+                name_id_map[attribute.name] = str(attribute.id)
+
+
+def _get_value_type_for_comparison(value: typing.Any) -> str:
+    """Gets the type of the value.
+    If the value is a number, returns "number" for comparison."""
+    if isinstance(value, numbers.Number) and not isinstance(value, bool):
+        return "number"
+    return type(value).__name__

--- a/hari_client/models/validation/attribute_validation.py
+++ b/hari_client/models/validation/attribute_validation.py
@@ -67,12 +67,8 @@ class AttributeConsistencyValidator:
         """Validates that attributes in a list have consistent value types and ids."""
         for attribute in self.attributes:
             self._check_attribute_id_usage(attribute)
-
             value_type = self._check_value_type(attribute)
-
-            # None values automatically pass the value type consistency check
-            if value_type != "NoneType":
-                self._check_list_elements_value_types(attribute, value_type)
+            self._check_list_elements_value_types(attribute, value_type)
 
     def _check_value_type(self, attribute: models.AttributeCreate) -> str:
         value_type = _get_value_type_for_comparison(attribute.value)

--- a/hari_client/models/validation/attribute_validation.py
+++ b/hari_client/models/validation/attribute_validation.py
@@ -8,26 +8,26 @@ from hari_client import models
 def validate_attributes(
     attributes: list[models.AttributeCreate],
 ) -> None:
-    """Raises an error if any requirements for attributes aren't met.
+    """Raises an error if any requirements for attribute consistency aren't met.
     Basic attribute requirements:
     - attributes with the same name and annotatable type must
-      - have the same id
-      - have the same value type
-    - attributes with value type list must
-      - contain only a single value type
-      - contain only the same value type as other attributes with the same name and annotatable type
-
-    Exceptions:
-      - The value `None` isn't taken into account when value type consistency is checked.
+        - have the same id
+        - have the same value type
+            - additionally attributes with value type list must
+                - have consistent list element value types (for example: all elements are strings; the list fits list[str])
+                - have consistent list element value types across all attributes with that name (for example: all attributes with name "my_attribute" have a value that fits list[str])
+            - Exceptions:
+                - The value `None` isn't taken into account when value type consistency is checked.
+                - Numeric types (int, float) are treated as the same value type can be mixed
 
     Args:
         attributes: List of attributes to validate.
 
     Raises:
         AttributeValidationInconsistentValueTypeError: If the value type for an attribute is inconsistent.
-        AttributeValidationInconsistentListElementValueTypesError: If the elements in a list attribute value have mixed value types.
+        AttributeValidationInconsistentListElementValueTypesError: If the elements in a list attribute value have inconsistent value types.
         AttributeValidationInconsistentListElementValueTypesMultipleAttributesError: If multiple list attributes have inconsistent element value types.
-        AttributeValidationIdNotReusedError: If another attribute with the same name and attribute type has a different id.
+        AttributeValidationIdNotReusedError: If multiple attributes with the same name and annotatable type have different ids.
     """
     grouped_by_annotatable_type: dict[str, list[models.AttributeCreate]] = {
         models.DataBaseObjectType.MEDIA: [],
@@ -37,93 +37,119 @@ def validate_attributes(
     for attribute in attributes:
         grouped_by_annotatable_type[attribute.annotatable_type].append(attribute)
 
-    for (
-        annotatable_type,
-        attributes_with_same_annotatable_type,
-    ) in grouped_by_annotatable_type.items():
-        # to check the value type consistency of attribute.value
-        name_value_type_map: dict[str, str] = {}
+    for attributes_with_same_annotatable_type in grouped_by_annotatable_type.values():
+        validator = AttributeConsistencyValidator(
+            attributes=attributes_with_same_annotatable_type
+        )
+        validator.validate_attributes()
 
-        # to check the value type consistency of list elements, when attribute.value is a list
-        name_list_element_value_type_map: dict[str, str] = {}
 
-        # to check whether the ids are reused as expected
-        name_id_map: dict[str, str] = {}
+class AttributeConsistencyValidator:
+    attributes: list[models.AttributeCreate]
 
-        for attribute in attributes_with_same_annotatable_type:
-            # check value type
-            value_type = _get_value_type_for_comparison(attribute.value)
+    # to check the value type consistency of attribute.value
+    name_value_type_map: dict[str, str]
+
+    # to check the value type consistency of list elements, when attribute.value is a list
+    name_list_element_value_type_map: dict[str, str]
+
+    # to check whether the ids are reused as expected
+    name_id_map: dict[str, str]
+
+    def __init__(self, attributes: list[models.AttributeCreate]):
+        self.attributes = attributes
+        self.name_value_type_map = {}
+        self.name_list_element_value_type_map = {}
+        self.name_id_map = {}
+
+    def validate_attributes(self) -> None:
+        """Validates that attributes in a list have consistent value types and ids."""
+        for attribute in self.attributes:
+            value_type = self._check_value_type(attribute)
+
             # None values automatically pass the value type consistency check
-            if value_type == "NoneType":
+            if value_type != "NoneType":
+                self._check_list_elements_value_types(attribute, value_type)
+
+            self._check_attribute_id_usage(attribute)
+
+    def _check_value_type(self, attribute: models.AttributeCreate) -> str:
+        value_type = _get_value_type_for_comparison(attribute.value)
+
+        # None values automatically pass the value type consistency check
+        if value_type == "NoneType":
+            return value_type
+
+        if attribute.name in self.name_value_type_map:
+            if self.name_value_type_map[attribute.name] != value_type:
+                raise errors.AttributeValidationInconsistentValueTypeError(
+                    attribute_name=attribute.name,
+                    annotatable_type=attribute.annotatable_type,
+                    found_value_types=[
+                        self.name_value_type_map[attribute.name],
+                        value_type,
+                    ],
+                )
+        else:
+            self.name_value_type_map[attribute.name] = value_type
+
+        return value_type
+
+    def _check_list_elements_value_types(
+        self, attribute: models.AttributeCreate, value_type: str
+    ) -> None:
+        # check list elements if value type is list
+        if value_type != "list" or attribute.value == []:
+            return
+
+        found_list_element_value_types: set[str] = set()
+        for element in attribute.value:
+            element_value_type = _get_value_type_for_comparison(element)
+            if element_value_type == "NoneType":
                 continue
-
-            if attribute.name in name_value_type_map:
-                if name_value_type_map[attribute.name] != value_type:
-                    raise errors.AttributeValidationInconsistentValueTypeError(
-                        attribute_name=attribute.name,
-                        annotatable_type=annotatable_type,
-                        found_value_types=[
-                            name_value_type_map[attribute.name],
-                            value_type,
-                        ],
-                    )
             else:
-                name_value_type_map[attribute.name] = value_type
+                found_list_element_value_types.add(element_value_type)
 
-            # check list elements if value type is list
-            if value_type == "list":
-                if attribute.value == []:
-                    continue
-                found_list_element_value_types: set[str] = set()
-                for element in attribute.value:
-                    element_value_type = _get_value_type_for_comparison(element)
-                    if element_value_type == "NoneType":
-                        continue
-                    else:
-                        found_list_element_value_types.add(element_value_type)
+        # check list element value type consistency within the attribute
+        if len(found_list_element_value_types) > 1:
+            raise errors.AttributeValidationInconsistentListElementValueTypesError(
+                attribute_name=attribute.name,
+                annotatable_type=attribute.annotatable_type,
+                found_value_types=found_list_element_value_types,
+            )
+        # check list element value type consistency across attributes
+        attribute_list_element_value_type = list(found_list_element_value_types)[0]
+        if attribute.name in self.name_list_element_value_type_map:
+            if (
+                self.name_list_element_value_type_map[attribute.name]
+                != attribute_list_element_value_type
+            ):
+                raise errors.AttributeValidationInconsistentListElementValueTypesMultipleAttributesError(
+                    attribute_name=attribute.name,
+                    annotatable_type=attribute.annotatable_type,
+                    found_value_types=[
+                        self.name_list_element_value_type_map[attribute.name],
+                        attribute_list_element_value_type,
+                    ],
+                )
+        else:
+            self.name_list_element_value_type_map[
+                attribute.name
+            ] = attribute_list_element_value_type
 
-                # check list element value type consistency within the attribute
-                if len(found_list_element_value_types) > 1:
-                    raise errors.AttributeValidationInconsistentListElementValueTypesError(
-                        attribute_name=attribute.name,
-                        annotatable_type=annotatable_type,
-                        found_value_types=found_list_element_value_types,
-                    )
-                # check list element value type consistency across attributes
-                attribute_list_element_value_type = list(
-                    found_list_element_value_types
-                )[0]
-                if attribute.name in name_list_element_value_type_map:
-                    if (
-                        name_list_element_value_type_map[attribute.name]
-                        != attribute_list_element_value_type
-                    ):
-                        raise errors.AttributeValidationInconsistentListElementValueTypesMultipleAttributesError(
-                            attribute_name=attribute.name,
-                            annotatable_type=annotatable_type,
-                            found_value_types=[
-                                name_list_element_value_type_map[attribute.name],
-                                attribute_list_element_value_type,
-                            ],
-                        )
-                else:
-                    name_list_element_value_type_map[
-                        attribute.name
-                    ] = attribute_list_element_value_type
-
-            # check id
-            if attribute.name in name_id_map:
-                if name_id_map[attribute.name] != str(attribute.id):
-                    raise errors.AttributeValidationIdNotReusedError(
-                        attribute_name=attribute.name,
-                        annotatable_type=annotatable_type,
-                        found_ids=[
-                            name_id_map[attribute.name],
-                            str(attribute.id),
-                        ],
-                    )
-            else:
-                name_id_map[attribute.name] = str(attribute.id)
+    def _check_attribute_id_usage(self, attribute: models.AttributeCreate) -> None:
+        if attribute.name in self.name_id_map:
+            if self.name_id_map[attribute.name] != str(attribute.id):
+                raise errors.AttributeValidationIdNotReusedError(
+                    attribute_name=attribute.name,
+                    annotatable_type=attribute.annotatable_type,
+                    found_ids=[
+                        self.name_id_map[attribute.name],
+                        str(attribute.id),
+                    ],
+                )
+        else:
+            self.name_id_map[attribute.name] = str(attribute.id)
 
 
 def _get_value_type_for_comparison(value: typing.Any) -> str:

--- a/hari_client/models/validation/attribute_validation.py
+++ b/hari_client/models/validation/attribute_validation.py
@@ -5,15 +5,20 @@ from hari_client import errors
 from hari_client import models
 
 
-def validate_initial_attributes(
+def validate_attributes(
     attributes: list[models.AttributeCreate],
 ) -> None:
-    """Raises an error if any requirements for initial attributes aren't met.
-    Attribute requirements:
+    """Raises an error if any requirements for attributes aren't met.
+    Basic attribute requirements:
     - attributes with the same name and annotatable type must
-        - have the same value type
-        - have the same id
-    - attributes with value type list, mustn't contain multiple value types in the list
+      - have the same id
+      - have the same value type
+    - attributes with value type list must
+      - contain only a single value type
+      - contain only the same value type as other attributes with the same name and annotatable type
+
+    Exceptions:
+      - The value `None` isn't taken into account when value type consistency is checked.
 
     Args:
         attributes: List of attributes to validate.
@@ -21,26 +26,37 @@ def validate_initial_attributes(
     Raises:
         AttributeValidationInconsistentValueTypeError: If the value type for an attribute is inconsistent.
         AttributeValidationInconsistentListElementValueTypesError: If the elements in a list attribute value have mixed value types.
+        AttributeValidationInconsistentListElementValueTypesMultipleAttributesError: If multiple list attributes have inconsistent element value types.
         AttributeValidationIdNotReusedError: If another attribute with the same name and attribute type has a different id.
     """
-    grouped_by_attribute_type: dict[str, list[models.AttributeCreate]] = {
+    grouped_by_annotatable_type: dict[str, list[models.AttributeCreate]] = {
         models.DataBaseObjectType.MEDIA: [],
         models.DataBaseObjectType.MEDIAOBJECT: [],
         models.DataBaseObjectType.INSTANCE: [],
     }
     for attribute in attributes:
-        grouped_by_attribute_type[attribute.annotatable_type].append(attribute)
+        grouped_by_annotatable_type[attribute.annotatable_type].append(attribute)
 
     for (
         annotatable_type,
         attributes_with_same_annotatable_type,
-    ) in grouped_by_attribute_type.items():
+    ) in grouped_by_annotatable_type.items():
+        # to check the value type consistency of attribute.value
         name_value_type_map: dict[str, str] = {}
+
+        # to check the value type consistency of list elements, when attribute.value is a list
+        name_list_element_value_type_map: dict[str, str] = {}
+
+        # to check whether the ids are reused as expected
         name_id_map: dict[str, str] = {}
 
         for attribute in attributes_with_same_annotatable_type:
             # check value type
             value_type = _get_value_type_for_comparison(attribute.value)
+            # None values automatically pass the value type consistency check
+            if value_type == "NoneType":
+                continue
+
             if attribute.name in name_value_type_map:
                 if name_value_type_map[attribute.name] != value_type:
                     raise errors.AttributeValidationInconsistentValueTypeError(
@@ -56,17 +72,44 @@ def validate_initial_attributes(
 
             # check list elements if value type is list
             if value_type == "list":
+                if attribute.value == []:
+                    continue
                 found_list_element_value_types: set[str] = set()
                 for element in attribute.value:
-                    found_list_element_value_types.add(
-                        _get_value_type_for_comparison(element)
-                    )
+                    element_value_type = _get_value_type_for_comparison(element)
+                    if element_value_type == "NoneType":
+                        continue
+                    else:
+                        found_list_element_value_types.add(element_value_type)
+
+                # check list element value type consistency within the attribute
                 if len(found_list_element_value_types) > 1:
                     raise errors.AttributeValidationInconsistentListElementValueTypesError(
                         attribute_name=attribute.name,
                         annotatable_type=annotatable_type,
                         found_value_types=found_list_element_value_types,
                     )
+                # check list element value type consistency across attributes
+                attribute_list_element_value_type = list(
+                    found_list_element_value_types
+                )[0]
+                if attribute.name in name_list_element_value_type_map:
+                    if (
+                        name_list_element_value_type_map[attribute.name]
+                        != attribute_list_element_value_type
+                    ):
+                        raise errors.AttributeValidationInconsistentListElementValueTypesMultipleAttributesError(
+                            attribute_name=attribute.name,
+                            annotatable_type=annotatable_type,
+                            found_value_types=[
+                                name_list_element_value_type_map[attribute.name],
+                                attribute_list_element_value_type,
+                            ],
+                        )
+                else:
+                    name_list_element_value_type_map[
+                        attribute.name
+                    ] = attribute_list_element_value_type
 
             # check id
             if attribute.name in name_id_map:

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -376,14 +376,7 @@ class HARIUploader:
         self._assign_object_category_subsets()
 
     def validate_all_attributes(self) -> None:
-        """Validates all attributes of medias and media objects.
-
-        Raises:
-            AttributeValidationInconsistentValueTypeError: If the value type for an attribute is inconsistent.
-            AttributeValidationInconsistentListElementValueTypesError: If the elements in a list attribute value have mixed value types.
-            AttributeValidationInconsistentListElementValueTypesMultipleAttributesError: If multiple list attributes have inconsistent element value types.
-            AttributeValidationIdNotReusedError: If another attribute with the same name and attribute type has a different id.
-        """
+        """Validates all attributes of medias and media objects."""
         all_attributes = []
         for media in self._medias:
             all_attributes.extend(media.attributes)

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -381,6 +381,7 @@ class HARIUploader:
         Raises:
             AttributeValidationInconsistentValueTypeError: If the value type for an attribute is inconsistent.
             AttributeValidationInconsistentListElementValueTypesError: If the elements in a list attribute value have mixed value types.
+            AttributeValidationInconsistentListElementValueTypesMultipleAttributesError: If multiple list attributes have inconsistent element value types.
             AttributeValidationIdNotReusedError: If another attribute with the same name and attribute type has a different id.
         """
         all_attributes = []
@@ -388,7 +389,7 @@ class HARIUploader:
             all_attributes.extend(media.attributes)
             for media_object in media.media_objects:
                 all_attributes.extend(media_object.attributes)
-        validation.validate_initial_attributes(all_attributes)
+        validation.validate_attributes(all_attributes)
 
     def upload(
         self,

--- a/tests/test_attribute_validations.py
+++ b/tests/test_attribute_validations.py
@@ -114,6 +114,38 @@ def test_attribute_validation_inconsistent_value_type(attributes):
                 name="a",
                 annotatable_id="media_0",
                 annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=None,
+            ),
+            models.AttributeCreate(
+                id=_some_uuids[1],
+                name="a",
+                annotatable_id="media_0",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=5,
+            ),
+        ],
+        [
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_0",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=5,
+            ),
+            models.AttributeCreate(
+                id=_some_uuids[1],
+                name="a",
+                annotatable_id="media_1",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=None,
+            ),
+        ],
+        [
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_0",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
                 value=True,
             ),
             models.AttributeCreate(

--- a/tests/test_attribute_validations.py
+++ b/tests/test_attribute_validations.py
@@ -35,6 +35,38 @@ _some_uuids = [uuid.uuid4() for _ in range(10)]
                 name="a",
                 annotatable_id="media_0",
                 annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=[5],
+            ),
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_1",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value="7",
+            ),
+        ],
+        [
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_0",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=[],
+            ),
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_1",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value="7",
+            ),
+        ],
+        [
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_0",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
                 value=True,
             ),
             models.AttributeCreate(
@@ -271,7 +303,7 @@ def test_attribute_validation_id_not_reused(attributes):
                     value=[True, False, False],
                 ),
                 models.AttributeCreate(
-                    id=_some_uuids[1],
+                    id=_some_uuids[0],
                     name="a",
                     annotatable_id="media_object_2",
                     annotatable_type=models.DataBaseObjectType.MEDIAOBJECT,
@@ -399,3 +431,183 @@ def test_attribute_validation_is_used_in_hari_uploader(
         media_object_attributes[1].annotatable_type
         == models.DataBaseObjectType.MEDIAOBJECT
     )
+
+
+def test_attribute_validations_successful_case():
+    attributes = [
+        # numeric attribute
+        models.AttributeCreate(
+            id=_some_uuids[0],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_1",
+            name="my_number",
+            value=42,
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[0],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_2",
+            name="my_number",
+            value=43.643,
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[0],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_3",
+            name="my_number",
+            value=None,
+        ),
+        # string attribute
+        models.AttributeCreate(
+            id=_some_uuids[1],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_1",
+            name="my_string",
+            value="hello",
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[1],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_2",
+            name="my_string",
+            value="world",
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[1],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_3",
+            name="my_string",
+            value=None,
+        ),
+        # boolean attribute
+        models.AttributeCreate(
+            id=_some_uuids[2],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_1",
+            name="my_boolean",
+            value=True,
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[2],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_2",
+            name="my_boolean",
+            value=False,
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[2],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_3",
+            name="my_boolean",
+            value=None,
+        ),
+        # numeric list attribute
+        models.AttributeCreate(
+            id=_some_uuids[3],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_1",
+            name="my_numeric_list",
+            value=[0, 1, 2, 2.55],
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[3],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_2",
+            name="my_numeric_list",
+            value=[3.5, 4, None, 5],
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[3],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_3",
+            name="my_numeric_list",
+            value=None,
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[3],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_4",
+            name="my_numeric_list",
+            value=[None],
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[3],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_5",
+            name="my_numeric_list",
+            value=[],
+        ),
+        # boolean list attribute
+        models.AttributeCreate(
+            id=_some_uuids[4],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_1",
+            name="my_boolean_list",
+            value=[True, False, False],
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[4],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_2",
+            name="my_boolean_list",
+            value=[None, False, None, None],
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[4],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_3",
+            name="my_boolean_list",
+            value=None,
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[4],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_4",
+            name="my_boolean_list",
+            value=[None],
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[4],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_5",
+            name="my_boolean_list",
+            value=[],
+        ),
+        # string list attribute
+        models.AttributeCreate(
+            id=_some_uuids[5],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_1",
+            name="my_string_list",
+            value=["hello", None, "world"],
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[5],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_2",
+            name="my_string_list",
+            value=["0", "1", "5.33", None, "banana"],
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[5],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_3",
+            name="my_string_list",
+            value=None,
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[5],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_4",
+            name="my_string_list",
+            value=[None],
+        ),
+        models.AttributeCreate(
+            id=_some_uuids[5],
+            annotatable_type=models.DataBaseObjectType.MEDIA,
+            annotatable_id="media_5",
+            name="my_string_list",
+            value=[],
+        ),
+    ]
+    validation.validate_attributes(attributes)

--- a/tests/test_attribute_validations.py
+++ b/tests/test_attribute_validations.py
@@ -1,0 +1,277 @@
+import uuid
+
+import pytest
+
+from hari_client import errors
+from hari_client import hari_uploader
+from hari_client import models
+from hari_client import validation
+
+_some_uuids = [uuid.uuid4() for _ in range(10)]
+
+
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        [
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_0",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=5,
+            ),
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_1",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value="7",
+            ),
+        ],
+        [
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_0",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=True,
+            ),
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_1",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=None,
+            ),
+        ],
+        [
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_0",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=True,
+            ),
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_1",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=False,
+            ),
+            models.AttributeCreate(
+                id=_some_uuids[1],
+                name="b",
+                annotatable_id="media_object_0",
+                annotatable_type=models.DataBaseObjectType.MEDIAOBJECT,
+                value="banana",
+            ),
+            models.AttributeCreate(
+                id=_some_uuids[1],
+                name="b",
+                annotatable_id="media_object_1",
+                annotatable_type=models.DataBaseObjectType.MEDIAOBJECT,
+                value=0,
+            ),
+        ],
+    ],
+)
+def test_initial_attribute_validation_inconsistent_value_type(attributes):
+    with pytest.raises(errors.AttributeValidationInconsistentValueTypeError):
+        validation.validate_initial_attributes(attributes)
+
+
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        [
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_0",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=5,
+            ),
+            models.AttributeCreate(
+                id=_some_uuids[1],
+                name="a",
+                annotatable_id="media_1",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=7,
+            ),
+        ],
+        [
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_0",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=True,
+            ),
+            models.AttributeCreate(
+                id=_some_uuids[1],
+                name="a",
+                annotatable_id="media_object_1",
+                annotatable_type=models.DataBaseObjectType.MEDIAOBJECT,
+                value=42,
+            ),
+            models.AttributeCreate(
+                id=_some_uuids[2],
+                name="a",
+                annotatable_id="media_object_2",
+                annotatable_type=models.DataBaseObjectType.MEDIAOBJECT,
+                value=37,
+            ),
+        ],
+    ],
+)
+def test_initial_attribute_validation_id_not_reused(attributes):
+    with pytest.raises(errors.AttributeValidationIdNotReusedError):
+        validation.validate_initial_attributes(attributes)
+
+
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        [
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_0",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=[7, 8, 2, 1, 0],
+            ),
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_1",
+                annotatable_type=models.DataBaseObjectType.MEDIA,
+                value=[5, 3, "seven", 4, 42],
+            ),
+        ],
+        [
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_object_0",
+                annotatable_type=models.DataBaseObjectType.MEDIAOBJECT,
+                value=[7, 8, 2, 1, 0],
+            ),
+            models.AttributeCreate(
+                id=_some_uuids[0],
+                name="a",
+                annotatable_id="media_object_1",
+                annotatable_type=models.DataBaseObjectType.MEDIAOBJECT,
+                value=[5, True, 4, 42],
+            ),
+        ],
+    ],
+)
+def test_initial_attribute_validation_inconsistent_list_element_value_types(attributes):
+    with pytest.raises(
+        errors.AttributeValidationInconsistentListElementValueTypesError
+    ):
+        validation.validate_initial_attributes(attributes)
+
+
+@pytest.mark.parametrize(
+    "media_attributes, media_object_attributes, expected_exception_to_raise",
+    [
+        (
+            [hari_uploader.HARIAttribute(id=_some_uuids[0], name="a", value=42)],
+            [
+                hari_uploader.HARIAttribute(
+                    id=_some_uuids[1], name="b", value="banana"
+                ),
+                hari_uploader.HARIAttribute(id=_some_uuids[1], name="b", value=47),
+            ],
+            errors.AttributeValidationInconsistentValueTypeError,
+        ),
+        (
+            [hari_uploader.HARIAttribute(id=_some_uuids[0], name="a", value=42)],
+            [
+                hari_uploader.HARIAttribute(
+                    id=_some_uuids[1], name="b", value="banana"
+                ),
+                hari_uploader.HARIAttribute(
+                    id=_some_uuids[2], name="b", value="hello_world"
+                ),
+            ],
+            errors.AttributeValidationIdNotReusedError,
+        ),
+        (
+            [hari_uploader.HARIAttribute(id=_some_uuids[0], name="a", value=42)],
+            [
+                hari_uploader.HARIAttribute(
+                    id=_some_uuids[1], name="b", value=[1, 2, 42, 37]
+                ),
+                hari_uploader.HARIAttribute(
+                    id=_some_uuids[1], name="b", value=[1, 2, 3, "four"]
+                ),
+            ],
+            errors.AttributeValidationInconsistentListElementValueTypesError,
+        ),
+    ],
+)
+def test_initial_attribute_validation_is_used_in_hari_uploader(
+    media_attributes,
+    media_object_attributes,
+    expected_exception_to_raise,
+    create_configurable_mock_uploader_successful_single_batch,
+):
+    # Arrange
+    mock_uploader: hari_uploader.HARIUploader = (
+        create_configurable_mock_uploader_successful_single_batch(
+            dataset_id=uuid.uuid4(), medias_cnt=1, media_objects_cnt=2, attributes_cnt=3
+        )[0]
+    )
+    medias = [
+        hari_uploader.HARIMedia(
+            file_path="./img_1.jpg",
+            name="media_1",
+            media_type=models.MediaType.IMAGE,
+            back_reference="media_1 backref",
+        )
+    ]
+    media_object_1 = hari_uploader.HARIMediaObject(
+        back_reference="media object 1 backref",
+        reference_data=models.BBox2DCenterPoint(
+            type=models.BBox2DType.BBOX2D_CENTER_POINT,
+            x=100,
+            y=100,
+            width=200,
+            height=200,
+        ),
+    )
+    media_object_2 = hari_uploader.HARIMediaObject(
+        back_reference="media object 2 backref",
+        reference_data=models.BBox2DCenterPoint(
+            type=models.BBox2DType.BBOX2D_CENTER_POINT,
+            x=300,
+            y=300,
+            width=200,
+            height=200,
+        ),
+    )
+    for attribute in media_attributes:
+        medias[0].add_attribute(attribute)
+    media_object_1.add_attribute(media_object_attributes[0])
+    media_object_2.add_attribute(media_object_attributes[1])
+    medias[0].add_media_object(media_object_1, media_object_2)
+
+    # Act + Assert
+    mock_uploader.add_media(*medias)
+    with pytest.raises(expected_exception_to_raise):
+        mock_uploader.upload()
+
+    # attribute annotatable_type was set for all attributes
+    assert media_attributes[0].annotatable_type == models.DataBaseObjectType.MEDIA
+    assert (
+        media_object_attributes[0].annotatable_type
+        == models.DataBaseObjectType.MEDIAOBJECT
+    )
+    assert (
+        media_object_attributes[1].annotatable_type
+        == models.DataBaseObjectType.MEDIAOBJECT
+    )

--- a/tests/test_attribute_validations.py
+++ b/tests/test_attribute_validations.py
@@ -160,6 +160,18 @@ def test_attribute_validation_id_not_reused(attributes):
                     name="a",
                     annotatable_id="media_1",
                     annotatable_type=models.DataBaseObjectType.MEDIA,
+                    value=[5, 3, 4.666, 42],
+                ),
+            ],
+            None,
+        ),
+        (
+            [
+                models.AttributeCreate(
+                    id=_some_uuids[0],
+                    name="a",
+                    annotatable_id="media_1",
+                    annotatable_type=models.DataBaseObjectType.MEDIA,
                     value=[5, 3, False, 4, 42],
                 ),
                 models.AttributeCreate(
@@ -248,8 +260,11 @@ def test_attribute_validation_id_not_reused(attributes):
 def test_attribute_validation_inconsistent_list_element_value_types(
     attributes, expected_exception
 ):
-    with pytest.raises(expected_exception):
+    if expected_exception is None:
         validation.validate_attributes(attributes)
+    else:
+        with pytest.raises(expected_exception):
+            validation.validate_attributes(attributes)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_parse_response_model.py
+++ b/tests/test_parse_response_model.py
@@ -138,6 +138,7 @@ def test_parse_response_model_fails_for_response_data_not_matching_expected_resp
     [
         ([TestObject1], list[SimpleModel1], SimpleModel1),
         ([1, 2, 3], list[int], int),
+        ([], list[models.DatasetResponse], list),
     ],
 )
 def test_parse_response_model_works_with_list_of_parametrized_generics(


### PR DESCRIPTION
the validation is run automatically when using the hari_uploader's upload method.
Per default the validation is also run in the client's create_attributes method, but can be disabled with an arg, which the hari_uploader uses to prevent validation from running again for every batch.
Also took the opportunity to set the annotatable_type of attributes in the hari_uploader before the upload happens. Knowing the annotatable type is important for the validation.