### PR TITLE
Release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### New features
 
 - added "compute_auto_attributes"-param to trigger_metadata_rebuild_job [PR#71](https://github.com/quality-match/hari-client/pull/71)
+- add skip, limit, sort, query and archived parameters to get_datasets method [PR#67](https://github.com/quality-match/hari-client/pull/67)
+- add get_datasets_count method [PR#67](https://github.com/quality-match/hari-client/pull/67)
 
 ## [3.1.0] - 14-01-2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [major.minor.patch] - DD-MM-YYYY
 
+## [4.0.0] - TBD
+
+- removed `trigger_thumbnails_creation_job` and `trigger_crops_creation_job`
+
 ## [3.1.0] - 14-01-2025
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - restricted attribute `possible_values` to be a list of strings [PR#66](https://github.com/quality-match/hari-client/pull/66)
 - removed `trigger_thumbnails_creation_job` and `trigger_crops_creation_job` [PR#68](https://github.com/quality-match/hari-client/pull/68)
 
+### New features
+
+- added "compute_auto_attributes"-param to trigger_metadata_rebuild_job [PR#71](https://github.com/quality-match/hari-client/pull/71)
+
 ## [3.1.0] - 14-01-2025
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [4.0.0] - TBD
 
-- removed `trigger_thumbnails_creation_job` and `trigger_crops_creation_job`
+### Breaking Changes
+
+- restricted attribute `possible_values` to be a list of strings [PR#66](https://github.com/quality-match/hari-client/pull/66)
+- removed `trigger_thumbnails_creation_job` and `trigger_crops_creation_job` [PR#68](https://github.com/quality-match/hari-client/pull/68)
 
 ## [3.1.0] - 14-01-2025
 

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -1578,6 +1578,7 @@ class HARIClient:
         calculate_histograms: bool = True,
         trace_id: uuid.UUID | None = None,
         force_recreate: bool = False,
+        compute_auto_attributes: bool = False,
     ) -> list[models.BaseProcessingJobMethod]:
         """Triggers execution of one or more jobs which (re-)build metadata for all provided datasets.
 
@@ -1587,6 +1588,7 @@ class HARIClient:
             calculate_histograms: Calculate histograms if true
             trace_id: An id to trace the processing job
             force_recreate: If True already existing crops and thumbnails will be recreated; only available for qm internal users
+            compute_auto_attributes: If True auto attributes will be computed
 
         Returns:
             The methods being executed

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -1768,7 +1768,7 @@ class HARIClient:
         frequency: dict[str, int] | None = None,
         question: str | None = None,
         repeats: int | None = None,
-        possible_values: list[str | int | float | bool] | None = None,
+        possible_values: list[str] | None = None,
     ) -> models.Attribute:
         """Create an attribute for a dataset.
 

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -564,12 +564,24 @@ class HARIClient:
         self,
         subset: bool | None = False,
         visibility_statuses: tuple | None = (models.VisibilityStatus.VISIBLE,),
+        limit: int | None = None,
+        skip: int | None = None,
+        query: models.QueryList | None = None,
+        sort: list[models.SortingParameter] | None = None,
+        name_filter: str | None = None,
+        archived: bool | None = False,
     ) -> list[models.DatasetResponse]:
-        """Returns all datasets that a user has access to.
+        """Returns datasets that a user has access to.
 
         Args:
             subset: Return also subsets. If False, returns only parent datasets
             visibility_statuses: Visibility statuses of the returned datasets
+            limit: limit the number of datasets returned
+            skip: skip the number of datasets returned
+            query: query parameters to filter the datasets
+            sort: sorting parameters to sort the datasets
+            name_filter: filter by dataset name
+            archived: if true, return only archived datasets; if false (default), return non-archived datasets.
 
         Returns:
             A list of datasets
@@ -582,6 +594,34 @@ class HARIClient:
             "/datasets",
             params=self._pack(locals()),
             success_response_item_model=list[models.DatasetResponse],
+        )
+
+    def get_datasets_count(
+        self,
+        visibility_statuses: tuple | None = (models.VisibilityStatus.VISIBLE,),
+        query: models.QueryList | None = None,
+        name_filter: str | None = None,
+        archived: bool | None = False,
+    ) -> int:
+        """
+        Returns dataset count for the user.
+        Args:
+            visibility_statuses: Visibility statuses of the returned datasets
+            query: query parameters to filter the datasets
+            name_filter: filter by dataset name
+            archived: if true, count only archived datasets; if false (default), count non-archived datasets.
+
+        Returns:
+            The number of datasets
+
+        Raises:
+            APIException: If the request fails.
+        """
+        return self._request(
+            "GET",
+            "/datasets:count",
+            params=self._pack(locals()),
+            success_response_item_model=int,
         )
 
     def get_subsets_for_dataset(
@@ -909,7 +949,7 @@ class HARIClient:
 
         Args:
             dataset_id: The dataset id
-            archived: Whether to get archived media
+            archived: if true, return only archived medias; if false (default), return non-archived medias.
             presign_medias: Whether to presign medias
             limit: The number of medias tu return
             skip: The number of medias to skip
@@ -1044,7 +1084,7 @@ class HARIClient:
         Args:
             dataset_id: The dataset id
             subset_id: The subset id or None, if the result for the whole dataset
-            archived: Whether to consider archived medias (default: False)
+            archived: if true, consider only archived medias; if false (default), consider only non-archived medias.
 
         Returns:
             Dictionary, where the key is the number of medias in the dataset having
@@ -1070,7 +1110,7 @@ class HARIClient:
 
         Args:
             dataset_id: The dataset id
-            archived: Whether to consider archived medias
+            archived: if true, consider only archived medias; if false (default), consider only non-archived medias.
             query: Query
 
         Returns:
@@ -1394,11 +1434,11 @@ class HARIClient:
         query: models.QueryList | None = None,
         sort: list[models.SortingParameter] | None = None,
     ) -> list[models.MediaObjectResponse]:
-        """Queries the database based on the submitted parameters and returns a
+        """Queries the database based on the submitted parameters and returns a list of media objects
 
         Args:
             dataset_id: dataset id
-            archived: Archived
+            archived: if true, return only archived media objects; if false (default), return non-archived media objects.
             presign_medias: Presign Medias
             limit: Limit
             skip: Skip
@@ -1470,7 +1510,7 @@ class HARIClient:
 
         Args:
             dataset_id: dataset id
-            archived: Archived
+            archived: if true, consider only archived media objects; if false (default), consider only non-archived media objects.
             query: Query
 
         Returns:
@@ -1830,7 +1870,7 @@ class HARIClient:
 
         Args:
             dataset_id: The dataset id
-            archived: True if archived attributes should be returned
+            archived: if true, return only archived attributes; if false (default), return non-archived attributes.
             limit: The maximum number of attributes to return
             skip: The number of attributes to skip
             query: A query to filter attributes
@@ -1984,9 +2024,7 @@ class HARIClient:
 
         Args:
             dataset_id: The dataset id
-            archived: Filters items based on their archived status (default: False):
-              - if set (True/False), returns only archived or non-archived items, respectively
-              - if None, returns all items, regardless of their archived status
+            archived: if true, return only archived attribute metadata; if false (default), return non-archived attribute metadata.
             query: A query to filter attribute metadata
 
          Returns:
@@ -2017,7 +2055,7 @@ class HARIClient:
 
         Args:
             dataset_id (UUID): The ID of the dataset for which to retrieve visualization configurations.
-            archived: Whether to include archived VisualisationConfigs (default: False)
+            archived: if true, return only archived visualisation configurations; if false (default), return non-archived visualisation configurations.
             query: The filters to be applied to the search
             sort: The list of sorting parameters
             limit: How many visualisation_configs to return

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -1540,47 +1540,6 @@ class HARIClient:
         )
 
     ### metadata ###
-    def trigger_thumbnails_creation_job(
-        self,
-        dataset_id: uuid.UUID,
-        subset_id: uuid.UUID | None = None,
-        trace_id: uuid.UUID | None = None,
-        max_size: tuple[int, int] | None = None,
-        aspect_ratio: tuple[int, int] | None = None,
-        force_recreate: bool = False,
-    ) -> list[models.BaseProcessingJobMethod]:
-        """Triggers the creation of thumbnails for a given dataset.
-
-        Args:
-            dataset_id: The dataset id
-            subset_id: The subset id
-            trace_id: An id to trace the processing job(s). Is created by the user
-            max_size: The maximum size of the thumbnails
-            aspect_ratio: The aspect ratio of the thumbnails
-            force_recreate: If True already existing thumbnails will be recreated
-
-        Raises:
-            APIException: If the request fails.
-
-        Returns:
-            list[models.BaseProcessingJobMethod]: the methods being executed
-
-        Restrictions:
-            This endpoint is restricted to qm internal users only.
-        """
-        params = {"subset_id": subset_id, "force_recreate": force_recreate}
-
-        if trace_id is not None:
-            params["trace_id"] = trace_id
-
-        return self._request(
-            "PUT",
-            f"/datasets/{dataset_id}/thumbnails",
-            params=params,
-            json=self._pack(locals(), ignore=["dataset_id", "subset_id", "trace_id"]),
-            success_response_item_model=list[models.BaseProcessingJobMethod],
-        )
-
     def trigger_histograms_update_job(
         self,
         dataset_id: uuid.UUID,
@@ -1609,51 +1568,6 @@ class HARIClient:
             "PUT",
             f"/datasets/{dataset_id}/histograms",
             params=params,
-            success_response_item_model=list[models.BaseProcessingJobMethod],
-        )
-
-    def trigger_crops_creation_job(
-        self,
-        dataset_id: uuid.UUID,
-        subset_id: uuid.UUID | None = None,
-        trace_id: uuid.UUID | None = None,
-        padding_percent: int | None = None,
-        padding_minimum: int | None = None,
-        max_size: tuple[int, int] | None = None,
-        aspect_ratio: tuple[int, int] | None = None,
-        force_recreate: bool = False,
-    ) -> list[models.BaseProcessingJobMethod]:
-        """Creates the crops for a given dataset if the correct api key is provided in the request.
-
-        Args:
-            dataset_id: The dataset id
-            subset_id: The subset id
-            trace_id: An id to trace the processing job(s). Is created by the user
-            padding_percent: The padding (in percent) to add to the crops
-            padding_minimum: The minimum padding to add to the crops
-            max_size: The max size of the crops
-            aspect_ratio: The aspect ratio of the crops
-            force_recreate: If True already existing crops will be recreated
-
-        Raises:
-            APIException: If the request fails.
-
-        Returns:
-            list[models.BaseProcessingJobMethod]: The methods being executed
-
-        Restrictions:
-            This endpoint is restricted to qm internal users only.
-        """
-        params = {"subset_id": subset_id, "force_recreate": force_recreate}
-
-        if trace_id is not None:
-            params["trace_id"] = trace_id
-
-        return self._request(
-            "PUT",
-            f"/datasets/{dataset_id}/crops",
-            params=params,
-            json=self._pack(locals(), ignore=["dataset_id", "subset_id", "trace_id"]),
             success_response_item_model=list[models.BaseProcessingJobMethod],
         )
 

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -952,7 +952,7 @@ class AttributeCreate(BaseModel):
     frequency: dict[str, int] | None = None
     question: str | None = None
     repeats: int | None = None
-    possible_values: list[str | int | float | bool] | None = None
+    possible_values: list[str] | None = None
 
     @pydantic.model_validator(mode="before")
     @classmethod
@@ -997,7 +997,7 @@ class Attribute(BaseModel):
     ml_probability_distributions: dict[str, float] | None = None
     cant_solve_ratio: float | None = None
     repeats: int | None = None
-    possible_values: list[str | int | float | bool] | None = None
+    possible_values: list[str] | None = None
 
 
 class AttributeResponse(BaseModel):
@@ -1064,7 +1064,7 @@ class AttributeResponse(BaseModel):
         title="Repeats",
         description="Number of repeats for this attribute",
     )
-    possible_values: list[str | int | float | bool] | None = pydantic.Field(
+    possible_values: list[str] | None = pydantic.Field(
         default=None,
         title="Possible Values",
         description="Possible values for this attribute",


### PR DESCRIPTION
## Background
Using release branch to align the client release with its changes in the API
 - /datasets/{dataset_id}/thumbnails
 - /datasets/{dataset_id}/crops
    were removed in the API
    
- possible values for attributes are restricted to be a list of strings

This needs to be released after these changes are live in the API

## Changes
Remove trigger_thumbnails_creation_job and trigger_crops_creation_job

## Monday

https://quality-match.monday.com/boards/1606259534/pulses/1797705485