### PR TITLE
Ml/metadata rebuild optional auto attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## [major.minor.patch] - DD-MM-YYYY
 
-### New Features
+## [4.0.0] - TBD
+
+### Breaking Changes
+
+- restricted attribute `possible_values` to be a list of strings [PR#66](https://github.com/quality-match/hari-client/pull/66)
+- removed `trigger_thumbnails_creation_job` and `trigger_crops_creation_job` [PR#68](https://github.com/quality-match/hari-client/pull/68)
+
+### New features
 - added "compute_auto_attributes"-param to trigger_metadata_rebuild_job
 
 ## [3.1.0] - 14-01-2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [major.minor.patch] - DD-MM-YYYY
 
+### New Features
+- added "compute_auto_attributes"-param to trigger_metadata_rebuild_job
+
 ## [3.1.0] - 14-01-2025
 
 ### New Features

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -1664,6 +1664,7 @@ class HARIClient:
         calculate_histograms: bool = True,
         trace_id: uuid.UUID | None = None,
         force_recreate: bool = False,
+        compute_auto_attributes: bool = False,
     ) -> list[models.BaseProcessingJobMethod]:
         """Triggers execution of one or more jobs which (re-)build metadata for all provided datasets.
 
@@ -1673,6 +1674,7 @@ class HARIClient:
             calculate_histograms: Calculate histograms if true
             trace_id: An id to trace the processing job
             force_recreate: If True already existing crops and thumbnails will be recreated; only available for qm internal users
+            compute_auto_attributes: If True auto attributes will be computed
 
         Returns:
             The methods being executed

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -1540,47 +1540,6 @@ class HARIClient:
         )
 
     ### metadata ###
-    def trigger_thumbnails_creation_job(
-        self,
-        dataset_id: uuid.UUID,
-        subset_id: uuid.UUID | None = None,
-        trace_id: uuid.UUID | None = None,
-        max_size: tuple[int, int] | None = None,
-        aspect_ratio: tuple[int, int] | None = None,
-        force_recreate: bool = False,
-    ) -> list[models.BaseProcessingJobMethod]:
-        """Triggers the creation of thumbnails for a given dataset.
-
-        Args:
-            dataset_id: The dataset id
-            subset_id: The subset id
-            trace_id: An id to trace the processing job(s). Is created by the user
-            max_size: The maximum size of the thumbnails
-            aspect_ratio: The aspect ratio of the thumbnails
-            force_recreate: If True already existing thumbnails will be recreated
-
-        Raises:
-            APIException: If the request fails.
-
-        Returns:
-            list[models.BaseProcessingJobMethod]: the methods being executed
-
-        Restrictions:
-            This endpoint is restricted to qm internal users only.
-        """
-        params = {"subset_id": subset_id, "force_recreate": force_recreate}
-
-        if trace_id is not None:
-            params["trace_id"] = trace_id
-
-        return self._request(
-            "PUT",
-            f"/datasets/{dataset_id}/thumbnails",
-            params=params,
-            json=self._pack(locals(), ignore=["dataset_id", "subset_id", "trace_id"]),
-            success_response_item_model=list[models.BaseProcessingJobMethod],
-        )
-
     def trigger_histograms_update_job(
         self,
         dataset_id: uuid.UUID,
@@ -1609,51 +1568,6 @@ class HARIClient:
             "PUT",
             f"/datasets/{dataset_id}/histograms",
             params=params,
-            success_response_item_model=list[models.BaseProcessingJobMethod],
-        )
-
-    def trigger_crops_creation_job(
-        self,
-        dataset_id: uuid.UUID,
-        subset_id: uuid.UUID | None = None,
-        trace_id: uuid.UUID | None = None,
-        padding_percent: int | None = None,
-        padding_minimum: int | None = None,
-        max_size: tuple[int, int] | None = None,
-        aspect_ratio: tuple[int, int] | None = None,
-        force_recreate: bool = False,
-    ) -> list[models.BaseProcessingJobMethod]:
-        """Creates the crops for a given dataset if the correct api key is provided in the request.
-
-        Args:
-            dataset_id: The dataset id
-            subset_id: The subset id
-            trace_id: An id to trace the processing job(s). Is created by the user
-            padding_percent: The padding (in percent) to add to the crops
-            padding_minimum: The minimum padding to add to the crops
-            max_size: The max size of the crops
-            aspect_ratio: The aspect ratio of the crops
-            force_recreate: If True already existing crops will be recreated
-
-        Raises:
-            APIException: If the request fails.
-
-        Returns:
-            list[models.BaseProcessingJobMethod]: The methods being executed
-
-        Restrictions:
-            This endpoint is restricted to qm internal users only.
-        """
-        params = {"subset_id": subset_id, "force_recreate": force_recreate}
-
-        if trace_id is not None:
-            params["trace_id"] = trace_id
-
-        return self._request(
-            "PUT",
-            f"/datasets/{dataset_id}/crops",
-            params=params,
-            json=self._pack(locals(), ignore=["dataset_id", "subset_id", "trace_id"]),
             success_response_item_model=list[models.BaseProcessingJobMethod],
         )
 
@@ -1856,7 +1770,7 @@ class HARIClient:
         frequency: dict[str, int] | None = None,
         question: str | None = None,
         repeats: int | None = None,
-        possible_values: list[str | int | float | bool] | None = None,
+        possible_values: list[str] | None = None,
     ) -> models.Attribute:
         """Create an attribute for a dataset.
 

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -952,7 +952,7 @@ class AttributeCreate(BaseModel):
     frequency: dict[str, int] | None = None
     question: str | None = None
     repeats: int | None = None
-    possible_values: list[str | int | float | bool] | None = None
+    possible_values: list[str] | None = None
 
     @pydantic.model_validator(mode="before")
     @classmethod
@@ -997,7 +997,7 @@ class Attribute(BaseModel):
     ml_probability_distributions: dict[str, float] | None = None
     cant_solve_ratio: float | None = None
     repeats: int | None = None
-    possible_values: list[str | int | float | bool] | None = None
+    possible_values: list[str] | None = None
 
 
 class AttributeResponse(BaseModel):
@@ -1064,7 +1064,7 @@ class AttributeResponse(BaseModel):
         title="Repeats",
         description="Number of repeats for this attribute",
     )
-    possible_values: list[str | int | float | bool] | None = pydantic.Field(
+    possible_values: list[str] | None = pydantic.Field(
         default=None,
         title="Possible Values",
         description="Possible values for this attribute",


### PR DESCRIPTION
## Background

HARI API allows optional param "compute_auto_attributes" for its metadata-endpoint

##Changes

Add "compute_auto_attributes"-param to trigger_metadata_rebuild_job

##Monday

https://quality-match.monday.com/boards/1606259534/pulses/1797705485
