### PR TITLE
added low level support for external media sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [major.minor.patch] - DD-MM-YYYY
 
+## [3.3.0] - DD-MM-YYYY
+
+### New features
+
+#### Support for external media sources
+
+- added support for defining external media sources when creating a dataset
+  - new field `external_media_source` in the `create_dataset` method [PR#72](https://github.com/quality-match/hari-client/pull/72)
+- added new endpoint `get_external_media_source` [PR#72](https://github.com/quality-match/hari-client/pull/72)
+
 ## [3.2.0] - 25-02-2025
 
 ### New features

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -455,6 +455,7 @@ class HARIClient:
         ) = models.VisibilityStatus.VISIBLE,
         data_root: str | None = "custom_upload",
         id: str | None = None,
+        external_media_source: models.ExternalMediaSourceAPICreate | None = None,
     ) -> models.Dataset:
         """Creates an empty dataset in the database.
 
@@ -478,6 +479,7 @@ class HARIClient:
             visibility_status: Visibility status of the new dataset
             data_root: Data root
             id: ID of the newly created dataset
+            external_media_source: External Media Source
 
         Returns:
             The created dataset
@@ -485,6 +487,9 @@ class HARIClient:
         Raises:
             APIException: If the request fails.
         """
+        if external_media_source:
+            external_media_source = external_media_source.model_dump()
+
         return self._request(
             "POST",
             "/datasets",
@@ -743,8 +748,29 @@ class HARIClient:
             success_response_item_model=str,
         )
 
-        ### media ###
+    ### external media source ###
+    def get_external_media_source(
+        self, external_media_source_id: uuid.UUID
+    ) -> models.ExternalMediaSourceAPIResponse:
+        """Returns an external media source with a given external_media_source_id.
 
+        Args:
+            external_media_source_id: external media source id
+
+        Returns:
+            The external media source with the given external_media_source_id
+
+        Raises:
+            APIException: If the request fails.
+        """
+        return self._request(
+            "GET",
+            f"/externalMediaSources/{external_media_source_id}",
+            params=self._pack(locals()),
+            success_response_item_model=models.ExternalMediaSourceAPIResponse,
+        )
+
+    ### media ###
     def create_media(
         self,
         dataset_id: uuid.UUID,

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -243,6 +243,52 @@ class VisualisationType(str, enum.Enum):
     RENDERED = "Rendered"
 
 
+class ExternalMediaSourceCredentialsType(str, enum.Enum):
+    AZURE_SAS_TOKEN = "azure_sas_token"
+    S3_CROSS_ACCOUNT_ACCESS = "s3_cross_account_access"
+
+
+class ExternalMediaSourceS3CrossAccountAccessInfo(BaseModel):
+    type: ExternalMediaSourceCredentialsType = (
+        ExternalMediaSourceCredentialsType.S3_CROSS_ACCOUNT_ACCESS
+    )
+    bucket_name: str
+    region: str
+
+
+class ExternalMediaSourceAzureCredentials(pydantic.BaseModel):
+    type: ExternalMediaSourceCredentialsType = (
+        ExternalMediaSourceCredentialsType.AZURE_SAS_TOKEN
+    )
+    container_name: str
+    account_name: str
+    sas_token: str
+
+
+class ExternalMediaSourceAPICreate(BaseModel):
+    credentials: (
+        ExternalMediaSourceS3CrossAccountAccessInfo
+        | ExternalMediaSourceAzureCredentials
+    )
+
+
+class ExternalMediaSourceCredentialsDB(pydantic.BaseModel):
+    type: ExternalMediaSourceCredentialsType
+    container_name: str | None
+    account_name: str | None
+    bucket_name: str | None
+    region: str | None
+
+
+class ExternalMediaSourceAPIResponse(BaseModel):
+    id: uuid.UUID
+    user_group: str
+    owner: uuid.UUID
+    # credentials field doesn't contain secrets
+    credentials: ExternalMediaSourceCredentialsDB
+    creation_timestamp: datetime.datetime
+
+
 class Dataset(BaseModel):
     id: uuid.UUID = pydantic.Field(title="Id")
     name: str = pydantic.Field(title="Name")
@@ -266,6 +312,9 @@ class Dataset(BaseModel):
     )
     visibility_status: VisibilityStatus | None = pydantic.Field(
         default="visible", title="VisibilityStatus"
+    )
+    external_media_source: ExternalMediaSourceAPICreate | None = pydantic.Field(
+        None, title="External Media Source"
     )
 
 
@@ -293,6 +342,7 @@ class DatasetResponse(BaseModel):
     visibility_status: VisibilityStatus | None = pydantic.Field(
         default=VisibilityStatus.VISIBLE, title="VisibilityStatus"
     )
+    external_media_source: uuid.UUID | None = None
 
 
 class Pose3D(BaseModel):


### PR DESCRIPTION
adds support for sending an external media source configuration when creating a dataset and added new endpoint to get an external media source, together with all necessary api models.

I want to use the base branch `external_media_sources` as a feature branch. A second PR with the updated HARIUploader flow will follow after this one.