### PR TITLE
hari-client and hari_uploader utility update for supporting external media sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@
 - added support for defining external media sources when creating a dataset
   - new field `external_media_source` in the `create_dataset` method [PR#73](https://github.com/quality-match/hari-client/pull/73)
 - added new endpoint `get_external_media_source` [PR#73](https://github.com/quality-match/hari-client/pull/73)
+- added new arg to client method `create_medias` [PR#74](https://github.com/quality-match/hari-client/pull/74)
+  - `with_media_file_upload` (default: `True`). Set this to `False` if you want to skip the upload of media files.
+  - the method will then only send the `BulkMediaCreate` instance to HARI.
+- added format validations for `HARIMedia` field `media_url` [PR#74](https://github.com/quality-match/hari-client/pull/74)
+  - the field was previously set automatically through the process of uploading media files.
+  - in order to work with a dataset that uses an external media source, you have to set the field explicitly.
+- updated usage of HARIUploader utility [PR#74](https://github.com/quality-match/hari-client/pull/74)
+  - when using an external media source, make sure to only set the `media_url` field of a `HARIMedia` and don't set the `file_path`.
+  - if all medias have a set `media_url` field, then media files will not be uploaded to HARI, but they're only setup with the api.
+  - if all medias have a set `file_path` field, then the uploader utility behaves as before and will upload media files to HARI.
 
 ## [3.2.0] - 25-02-2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   - new field `external_media_source` in the `create_dataset` method [PR#73](https://github.com/quality-match/hari-client/pull/73)
 - added new endpoint `get_external_media_source` [PR#73](https://github.com/quality-match/hari-client/pull/73)
 - added new arg to client method `create_medias` [PR#74](https://github.com/quality-match/hari-client/pull/74)
-  - `with_media_file_upload` (default: `True`). Set this to `False` if you want to skip the upload of media files. This way the upload will only create medias in HARI without uploading media files to QM storage.
+  - `with_media_files_upload` (default: `True`). Set this to `False` if you want to skip the upload of media files. This way the upload will only create medias in HARI without uploading media files to QM storage.
 - added format validations for `HARIMedia` field `media_url` [PR#74](https://github.com/quality-match/hari-client/pull/74)
   - the field was previously set automatically through the process of uploading media files.
   - in order to work with a dataset that uses an external media source, you have to set the field explicitly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,13 @@
   - new field `external_media_source` in the `create_dataset` method [PR#73](https://github.com/quality-match/hari-client/pull/73)
 - added new endpoint `get_external_media_source` [PR#73](https://github.com/quality-match/hari-client/pull/73)
 - added new arg to client method `create_medias` [PR#74](https://github.com/quality-match/hari-client/pull/74)
-  - `with_media_file_upload` (default: `True`). Set this to `False` if you want to skip the upload of media files.
-  - the method will then only send the `BulkMediaCreate` instance to HARI.
+  - `with_media_file_upload` (default: `True`). Set this to `False` if you want to skip the upload of media files. This way the upload will only create medias in HARI without uploading media files to QM storage.
 - added format validations for `HARIMedia` field `media_url` [PR#74](https://github.com/quality-match/hari-client/pull/74)
   - the field was previously set automatically through the process of uploading media files.
   - in order to work with a dataset that uses an external media source, you have to set the field explicitly.
-- updated usage of HARIUploader utility [PR#74](https://github.com/quality-match/hari-client/pull/74)
-  - when using an external media source, make sure to only set the `media_url` field of a `HARIMedia` and don't set the `file_path`.
-  - if all medias have a set `media_url` field, then media files will not be uploaded to HARI, but they're only setup with the api.
-  - if all medias have a set `file_path` field, then the uploader utility behaves as before and will upload media files to HARI.
+- updated HARIUploader utility to support using a dataset with an external media source [PR#74](https://github.com/quality-match/hari-client/pull/74)
+  - when your dataset is using an external media source, make sure to set the `media_url` field of `HARIMedia` and don't set the `file_path`.
+  - when your dataset isn't using an external media source, make sure to set the `file_path` field of `HARIMedia` and don't set the `media_url`.
 
 ## [3.2.0] - 25-02-2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - added new endpoint `get_external_media_source` [PR#73](https://github.com/quality-match/hari-client/pull/73)
 - added new arg to client method `create_medias` [PR#74](https://github.com/quality-match/hari-client/pull/74)
   - `with_media_files_upload` (default: `True`). Set this to `False` if you want to skip the upload of media files. This way the upload will only create medias in HARI without uploading media files to QM storage.
+- added new arg to client method `create_media` [PR#74](https://github.com/quality-match/hari-client/pull/74)
+  - `with_media_files_upload` (default: `True`). Set this to `False` if you want to skip the upload of the media file. This way the upload will only create medias in HARI without uploading media files to QM storage.
 - added format validations for `HARIMedia` field `media_url` [PR#74](https://github.com/quality-match/hari-client/pull/74)
   - the field was previously set automatically through the process of uploading media files.
   - in order to work with a dataset that uses an external media source, you have to set the field explicitly.

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -879,7 +879,7 @@ class HARIClient:
         else:
             media_dicts = []
             for media in medias:
-                if not media.file_path:
+                if not media.media_url:
                     raise errors.MediaCreateMissingMediaUrlError(media)
                 media_dicts.append(media.model_dump())
 

--- a/hari_client/client/client.py
+++ b/hari_client/client/client.py
@@ -844,7 +844,12 @@ class HARIClient:
         # 2. create the media in HARI
         json_body = self._pack(
             locals(),
-            ignore=["file_path", "dataset_id", "media_upload_responses"],
+            ignore=[
+                "file_path",
+                "dataset_id",
+                "media_upload_responses",
+                "with_media_files_upload",
+            ],
         )
         return self._request(
             "POST",

--- a/hari_client/client/errors.py
+++ b/hari_client/client/errors.py
@@ -42,7 +42,14 @@ class ParseResponseModelError(Exception):
 class MediaCreateMissingFilePathError(Exception):
     def __init__(self, media_create: models.MediaCreate):
         super().__init__(
-            f"The 'file_path' has to be set when using an instance of models.MediaCreate in HARIClient.create_medias() and with_media_file_upload is True. Found: {media_create.file_path=}"
+            f"The 'file_path' has to be set when using an instance of models.MediaCreate in HARIClient.create_medias() when with_media_file_upload is True. Found: {media_create.file_path=}"
+        )
+
+
+class MediaCreateMissingMediaUrlError(Exception):
+    def __init__(self, media_create: models.MediaCreate):
+        super().__init__(
+            f"The 'media_url' has to be set when using an instance of models.MediaCreate in HARIClient.create_medias() when with_media_file_upload is False. Found: {media_create.media_url=}"
         )
 
 

--- a/hari_client/client/errors.py
+++ b/hari_client/client/errors.py
@@ -42,14 +42,14 @@ class ParseResponseModelError(Exception):
 class MediaCreateMissingFilePathError(Exception):
     def __init__(self, media_create: models.MediaCreate):
         super().__init__(
-            f"The 'file_path' has to be set when using an instance of models.MediaCreate in HARIClient.create_medias() when with_media_file_upload is True. Found: {media_create.file_path=}"
+            f"The 'file_path' has to be set when using an instance of models.MediaCreate in HARIClient.create_medias() when with_media_files_upload is True. Found: {media_create.file_path=}"
         )
 
 
 class MediaCreateMissingMediaUrlError(Exception):
     def __init__(self, media_create: models.MediaCreate):
         super().__init__(
-            f"The 'media_url' has to be set when using an instance of models.MediaCreate in HARIClient.create_medias() when with_media_file_upload is False. Found: {media_create.media_url=}"
+            f"The 'media_url' has to be set when using an instance of models.MediaCreate in HARIClient.create_medias() when with_media_files_upload is False. Found: {media_create.media_url=}"
         )
 
 

--- a/hari_client/client/errors.py
+++ b/hari_client/client/errors.py
@@ -42,7 +42,7 @@ class ParseResponseModelError(Exception):
 class MediaCreateMissingFilePathError(Exception):
     def __init__(self, media_create: models.MediaCreate):
         super().__init__(
-            f"The 'file_path' has to be set when using an instance of models.MediaCreate in HARIClient.create_medias(). Found: {media_create.file_path=}"
+            f"The 'file_path' has to be set when using an instance of models.MediaCreate in HARIClient.create_medias() and with_media_file_upload is True. Found: {media_create.file_path=}"
         )
 
 

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -313,7 +313,7 @@ class Dataset(BaseModel):
     visibility_status: VisibilityStatus | None = pydantic.Field(
         default="visible", title="VisibilityStatus"
     )
-    external_media_source: ExternalMediaSourceAPICreate | None = pydantic.Field(
+    external_media_source: uuid.UUID | None = pydantic.Field(
         None, title="External Media Source"
     )
 
@@ -342,7 +342,9 @@ class DatasetResponse(BaseModel):
     visibility_status: VisibilityStatus | None = pydantic.Field(
         default=VisibilityStatus.VISIBLE, title="VisibilityStatus"
     )
-    external_media_source: uuid.UUID | None = None
+    external_media_source: uuid.UUID | None = pydantic.Field(
+        None, title="External Media Source"
+    )
 
 
 class Pose3D(BaseModel):

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -1,5 +1,7 @@
 import copy
+import re
 import typing
+import urllib.parse
 import uuid
 
 import pydantic
@@ -170,6 +172,43 @@ class HARIMedia(models.BulkMediaCreate):
             )
         return v
 
+    @pydantic.field_validator("media_url")
+    @classmethod
+    def media_url_is_valid(cls, v: str) -> str:
+        # In case we wanted to allow simple relative paths, too:
+        # if not v.startswith(("s3://", "http://", "https://")):
+        #     if re.match(r"^[^\s/]+(\.[a-zA-Z0-9]+)?$", v) or "/" in v:
+        #         return v
+        #     raise ValueError("Invalid URL or path format")
+
+        parsed_url = urllib.parse.urlparse(v)
+
+        if parsed_url.scheme not in ("https", "s3"):
+            raise ValueError("URL must start with https:// or s3://")
+
+        if parsed_url.scheme == "s3":
+            if not parsed_url.netloc:
+                raise ValueError("Invalid S3 URL format")
+        else:
+            # Azure Blob Storage HTTPS URL pattern
+            azure_pattern = re.compile(
+                r"^https://[a-z0-9]{3,24}\.blob\.core\.windows\.net/[^\s]+$",
+                re.IGNORECASE,
+            )
+
+            # AWS S3 HTTPS URL pattern (must include region)
+            aws_pattern = re.compile(
+                r"^https://([a-z0-9.-]+\.)?s3[.-][a-z0-9-]+\.amazonaws\.com/[^\s]+$",
+                re.IGNORECASE,
+            )
+
+            if not (azure_pattern.match(v) or aws_pattern.match(v)):
+                raise ValueError(
+                    "Invalid HTTPS URL format for S3 or Azure Blob Storage"
+                )
+
+        return v
+
 
 class HARIUploadResults(pydantic.BaseModel):
     medias: models.BulkResponse
@@ -205,6 +244,7 @@ class HARIUploader:
         # TODO: this should be a dict[str, uuid.UUID] as soon as the api models are updated
         self._object_category_subsets: dict[str, str] = {}
         self._unique_attribute_ids: set[str] = set()
+        self._with_media_file_upload: bool = True
 
     # TODO: add_media shouldn't do validation logic, because that expects that a specific order of operation is necessary,
     # specifically that means that media_objects and attributes have to be added to media before the media is added to the uploader.
@@ -415,6 +455,29 @@ class HARIUploader:
                 all_attributes.extend(media_object.attributes)
         validation.validate_attributes(all_attributes)
 
+    def _prepare_media_upload(self) -> None:
+        """Checks whether medias have to be uploaded or not, based on their file_path and media_url being set."""
+        with_media_file_upload_cnt = 0
+        with_media_url_cnt = 0
+        for media in self._medias:
+            if media.file_path:
+                with_media_file_upload_cnt += 1
+            elif media.media_url:
+                with_media_url_cnt += 1
+
+        if with_media_file_upload_cnt == len(self._medias):
+            self._with_media_file_upload = True
+        elif (
+            with_media_url_cnt == len(self._medias) and with_media_file_upload_cnt == 0
+        ):
+            self._with_media_file_upload = False
+        else:
+            raise HARIMediaUploadError(
+                "Found mixed file_path and media_url usage in HARIMedia. Use only one consistently."
+                + " If you're using an external media source, don't set the file_path of HARIMedia and only set the media_url."
+                + " If you're not using an external media source, don't set the media_url of HARIMedia and only set the file_path."
+            )
+
     def upload(
         self,
     ) -> HARIUploadResults | None:
@@ -451,6 +514,7 @@ class HARIUploader:
             )
 
         self.validate_all_attributes()
+        self._prepare_media_upload()
 
         self._handle_object_categories()
 
@@ -507,7 +571,9 @@ class HARIUploader:
 
         # upload media batch
         media_upload_response = self.client.create_medias(
-            dataset_id=self.dataset_id, medias=medias_to_upload
+            dataset_id=self.dataset_id,
+            medias=medias_to_upload,
+            with_media_file_upload=self._with_media_file_upload,
         )
         self._media_upload_progress.update(len(medias_to_upload))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,3 +15,13 @@ def test_client():
         hari_auth_url="auth_url",
     )
     yield HARIClient(config=test_config)
+
+
+@pytest.fixture()
+def test_client_mocked(test_client: HARIClient, mocker):
+    """Returns hari-client for testing that has the internal _request method mocked.
+    All endpoint methods to hari will return an empty dict.
+    Note that this doesn't cover media file upload related methods.
+    """
+    mocker.patch.object(test_client, "_request", return_value={})
+    yield test_client

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,6 +23,22 @@ def test_create_medias_with_missing_file_paths(test_client):
         client.create_medias(dataset_id="1234", medias=[media_create])
 
 
+def test_create_medias_with_missing_media_urls(test_client):
+    # Arrange
+    client = test_client
+    media_create = models.MediaCreate(
+        name="my test media",
+        back_reference="my test media backref",
+        media_type=models.MediaType.IMAGE,
+    )
+
+    # Act + Assert
+    with pytest.raises(errors.MediaCreateMissingMediaUrlError):
+        client.create_medias(
+            dataset_id="1234", medias=[media_create], with_media_files_upload=False
+        )
+
+
 def test_create_medias_with_different_file_extensions_works(test_client, mocker):
     # Arrange
     media_create_1 = models.MediaCreate(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -39,6 +39,116 @@ def test_create_medias_with_missing_media_urls(test_client):
         )
 
 
+def test_create_medias_without_media_files_upload(test_client_mocked, mocker):
+    # Arrange
+    upload_media_files_spy = mocker.spy(
+        test_client_mocked, "_upload_media_files_with_presigned_urls"
+    )
+    media_create = models.MediaCreate(
+        name="my test media",
+        back_reference="my test media backref",
+        media_type=models.MediaType.IMAGE,
+        media_url="https://mybucket.s3.eu-central-1.amazonaws.com/path/to/image_1.jpg",
+    )
+
+    # Act
+    test_client_mocked.create_medias(
+        dataset_id=uuid.uuid4(), medias=[media_create], with_media_files_upload=False
+    )
+
+    # Assert
+    assert upload_media_files_spy.call_count == 0
+
+
+def test_create_medias_with_media_files_upload(test_client_mocked, mocker):
+    # Arrange
+    mocker.patch.object(test_client_mocked, "_upload_media_files_with_presigned_urls")
+    upload_media_files_spy = mocker.spy(
+        test_client_mocked, "_upload_media_files_with_presigned_urls"
+    )
+    media_create = models.MediaCreate(
+        name="my test media",
+        back_reference="my test media backref",
+        media_type=models.MediaType.IMAGE,
+        file_path="path/to/image_1.jpg",
+    )
+
+    # Act
+    test_client_mocked.create_medias(
+        dataset_id=uuid.uuid4(), medias=[media_create], with_media_files_upload=True
+    )
+
+    # Assert
+    assert upload_media_files_spy.call_count == 1
+
+
+def test_create_media_with_missing_file_path(test_client_mocked, mocker):
+    with pytest.raises(errors.MediaCreateMissingFilePathError):
+        test_client_mocked.create_media(
+            dataset_id=uuid.uuid4(),
+            name="my test media",
+            back_reference="my test media backref",
+            media_type=models.MediaType.IMAGE,
+            file_path=None,
+            with_media_files_upload=True,
+        )
+
+
+def test_create_media_with_missing_media_url(test_client_mocked, mocker):
+    with pytest.raises(errors.MediaCreateMissingMediaUrlError):
+        test_client_mocked.create_media(
+            dataset_id=uuid.uuid4(),
+            name="my test media",
+            back_reference="my test media backref",
+            media_type=models.MediaType.IMAGE,
+            file_path=None,
+            with_media_files_upload=False,
+        )
+
+
+def test_create_media_with_media_file_upload(test_client_mocked, mocker):
+    # Arrange
+    mocker.patch.object(test_client_mocked, "_upload_media_files_with_presigned_urls")
+    upload_media_files_spy = mocker.spy(
+        test_client_mocked, "_upload_media_files_with_presigned_urls"
+    )
+
+    # Act
+    test_client_mocked.create_media(
+        dataset_id=uuid.uuid4(),
+        name="my test media",
+        back_reference="my test media backref",
+        media_type=models.MediaType.IMAGE,
+        file_path="path/to/image_1.jpg",
+        with_media_files_upload=True,
+    )
+
+    # Assert
+    assert upload_media_files_spy.call_count == 1
+
+
+def test_create_media_without_media_file_upload(test_client_mocked, mocker):
+    # Arrange
+    mocker.patch.object(test_client_mocked, "_upload_media_files_with_presigned_urls")
+    upload_media_files_spy = mocker.spy(
+        test_client_mocked, "_upload_media_files_with_presigned_urls"
+    )
+
+    # Act
+    test_client_mocked.create_media(
+        dataset_id=uuid.uuid4(),
+        name="my test media",
+        back_reference="my test media backref",
+        media_type=models.MediaType.IMAGE,
+        file_path=None,
+        media_url="https://mybucket.s3.eu-central-1.amazonaws.com/path/to/image_1.jpg",
+        with_media_files_upload=False,
+    )
+
+    # Assert
+    assert upload_media_files_spy.call_count == 0
+
+
 def test_create_medias_with_different_file_extensions_works(test_client, mocker):
     # Arrange
     media_create_1 = models.MediaCreate(

--- a/tests/upload/fixtures.py
+++ b/tests/upload/fixtures.py
@@ -146,6 +146,9 @@ def mock_uploader_for_batching(test_client, mocker):
         "_set_bulk_operation_annotatable_id",
         side_effect=id_setter_mock,
     )
+
+    mocker.patch.object(uploader, "_load_dataset", return_value=None)
+
     yield uploader, media_spy, media_object_spy, attribute_spy
 
 
@@ -209,6 +212,8 @@ def mock_uploader_for_bulk_operation_annotatable_id_setter(test_client, mocker):
     )
     id_setter_spy = mocker.spy(uploader, "_set_bulk_operation_annotatable_id")
 
+    mocker.patch.object(uploader, "_load_dataset", return_value=None)
+
     return uploader, id_setter_spy
 
 
@@ -230,6 +235,7 @@ def create_configurable_mock_uploader_successful_single_batch(mocker, test_clien
 
     mocked HARIUploader methods:
      - _set_bulk_operation_annotatable_id
+     - _load_dataset
 
     HARIUploader method spies:
      - _upload_media_batch
@@ -339,6 +345,7 @@ def create_configurable_mock_uploader_successful_single_batch(mocker, test_clien
             "_set_bulk_operation_annotatable_id",
             side_effect=id_setter_mock,
         )
+        mocker.patch.object(uploader, "_load_dataset", return_value=None)
         media_spy = mocker.spy(uploader, "_upload_media_batch")
         media_object_spy = mocker.spy(uploader, "_upload_media_object_batch")
         attribute_spy = mocker.spy(uploader, "_upload_attribute_batch")


### PR DESCRIPTION
1777395874

add support for skipping media file upload in create_medias and hari_uploader when all medias have a set media_url. HARIMedia validates whether the set media_url is valid as a url for an media in a dataset that uses an external media source