### PR TITLE
Ml/handle bulk upload fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## [major.minor.patch] - DD-MM-YYYY
 
+## [3.5.0] - TBD
+
+### New Features
+
+#### Consistency in partially failed uploads
+
+- partially failed bulk uploads of medias and media objects are now handled consistently
+  - for failed media uploads, any media_objects and attributes for these medias will not be tried to be uploaded
+  - for media_objects, any attributes for these media_objects will not be tried to be uploaded
+
+#### Better reporting of failed and skipped uploads
+
+- improved reporting of failed and skipped uploads
+  - failed uploads are now reported in the `HARIUploadResults.failures` field
+  - skipped uploads are now reported in the `HARIUploadResults.failures.skipped_media_objects` and `HARIUploadResults.failures.skipped_attributes` fields
+
 ## [3.4.0] - 07-03-2025
 
 ### New features

--- a/tests/test_hari_uploader.py
+++ b/tests/test_hari_uploader.py
@@ -459,7 +459,7 @@ def test_hari_uploader_creates_batches_correctly(mock_uploader_for_batching):
     assert media_spy.call_count == 11
     media_calls = media_spy.call_args_list
     for i in range(11):
-        assert len(media_calls[i].kwargs["medias_to_upload"]) == 100
+        assert len(media_calls[i].kwargs["medias"]) == 100
     assert len(uploader._medias) == 1100
 
     assert media_object_spy.call_count == 22
@@ -537,7 +537,7 @@ def test_hari_uploader_creates_single_batch_correctly(
     # check every batch upload method's call
     assert media_spy.call_count == 1
     media_calls = media_spy.call_args_list
-    assert len(media_calls[0].kwargs["medias_to_upload"]) == 5
+    assert len(media_calls[0].kwargs["medias"]) == 5
     assert len(uploader._medias) == 5
 
     assert media_object_spy.call_count == 1
@@ -615,7 +615,7 @@ def test_hari_uploader_creates_single_batch_correctly_without_uploading_media_fi
     # check every batch upload method's call
     assert media_spy.call_count == 1
     media_calls = media_spy.call_args_list
-    assert len(media_calls[0].kwargs["medias_to_upload"]) == 5
+    assert len(media_calls[0].kwargs["medias"]) == 5
     assert len(uploader._medias) == 5
 
     assert media_object_spy.call_count == 1


### PR DESCRIPTION
# Background
Partially failed uploads during the bulk upload of medias and media objects in the `upload`-method of the `HariUploader`-class would raise an error when depending media_objects or attributes would be attempted to upload. The uploader would assign an annotatable_id to media_objects and attributes AFTER the Hari API would respond with 201-status code for created objects. On failures, this annotatable_id could not be set, which led to an error.


# Changes
Handle partially failed uploads of media and media_objects consistently

    - cleaned up the uploader-method and made it more modular
