### PR TITLE
replace hari_api_base_url default with new api domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 - made `media_url` and `pii_media_url` optional in the `Media` model [PR#83](https://github.com/quality-match/hari-client/pull/83)
 
+### Internal
+
+- set new default value for `hari_api_base_url` in the config model [PR#85](https://github.com/quality-match/hari-client/pull/85)
+
 ## [3.4.0] - 07-03-2025
 
 ### New features

--- a/hari_client/config/config.py
+++ b/hari_client/config/config.py
@@ -35,7 +35,7 @@ class Config(pydantic_settings.BaseSettings):
         env_file=".env", env_file_encoding="utf-8", env_nested_delimiter="__"
     )
 
-    hari_api_base_url: str = "https://bbb.qm-annotations.com"
+    hari_api_base_url: str = "https://api.hari.quality-match.com"
     hari_client_id: str = "baked_beans_frontend"
     hari_auth_url: str = "https://auth.quality-match.com/auth"
     hari_username: str


### PR DESCRIPTION
As the primary HARI API domain was replaced by "api.hari.quality-match.com", we should set this as the new default.
Note that the old domain is still supported for some time to maintain compatibility.