### PR TITLE
[Patch] Add fake responses to keep server responses consistent when s…

### DIFF
--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -1123,6 +1123,7 @@ class ResponseStatesEnum(str, enum.Enum):
     SERVER_ERROR = "server_error"
     BAD_DATA = "bad_data"
     CONFLICT = "conflict"
+    SKIPPED = "skipped"
 
 
 class BaseBulkItemResponse(BaseModel, arbitrary_types_allowed=True):

--- a/hari_client/models/models.py
+++ b/hari_client/models/models.py
@@ -1123,7 +1123,6 @@ class ResponseStatesEnum(str, enum.Enum):
     SERVER_ERROR = "server_error"
     BAD_DATA = "bad_data"
     CONFLICT = "conflict"
-    SKIPPED = "skipped"
 
 
 class BaseBulkItemResponse(BaseModel, arbitrary_types_allowed=True):

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -974,6 +974,7 @@ class HARIUploader:
                         )
                     )
                     failed_media_objects.extend(media.media_objects)
+                    self._media_object_upload_progress.update(len(media.media_objects))
 
                     for media_object in media.media_objects:
                         self.failures.failed_media_object_attributes.extend(
@@ -988,6 +989,9 @@ class HARIUploader:
                             )
                         )
                         failed_media_object_attributes.extend(media_object.attributes)
+                        self._attribute_upload_progress.update(
+                            len(media_object.attributes)
+                        )
 
         # filter out media_objects and attributes that should be skipped because its media failed to upload
         media_objects_to_upload: list[HARIMediaObject] = [
@@ -1050,6 +1054,7 @@ class HARIUploader:
                         )
                     )
                     failed_media_object_attributes.extend(media_object.attributes)
+                    self._attribute_upload_progress.update(len(media_object.attributes))
 
         # update attributes to upload with the media_object attributes that should not be skipped
         for media_object in media_objects_to_upload:

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -1140,21 +1140,25 @@ class HARIUploader:
         """
         # handle skipped media objects and attributes
         if media_objects:
-            skipped_mo_resp = models.BulkResponse()
+            skipped_media_objects_resp = models.BulkResponse()
             for mo in media_objects:
-                skipped_mo_resp.results.append(
+                skipped_media_objects_resp.results.append(
                     models.AnnotatableCreateResponse(
                         bulk_operation_annotatable_id="",
                         item_id=None,
-                        status=models.ResponseStatesEnum.BAD_DATA,
+                        status=models.ResponseStatesEnum.SKIPPED,
                         errors=["Parent media upload failed. Skipping media object."],
                     )
                 )
             # ensure summary matches results count
-            skipped_mo_resp.summary.total = len(skipped_mo_resp.results)
-            skipped_mo_resp.summary.failed = len(skipped_mo_resp.results)
-            skipped_mo_resp.status = models.BulkOperationStatusEnum.FAILURE
-            media_object_upload_responses.append(skipped_mo_resp)
+            skipped_media_objects_resp.summary.total = len(
+                skipped_media_objects_resp.results
+            )
+            skipped_media_objects_resp.summary.failed = len(
+                skipped_media_objects_resp.results
+            )
+            skipped_media_objects_resp.status = models.BulkOperationStatusEnum.FAILURE
+            media_object_upload_responses.append(skipped_media_objects_resp)
 
         if attributes:
             skipped_attr_resp = models.BulkResponse()
@@ -1163,7 +1167,7 @@ class HARIUploader:
                     models.AttributeCreateResponse(
                         annotatable_id="",
                         item_id=None,
-                        status=models.ResponseStatesEnum.BAD_DATA,
+                        status=models.ResponseStatesEnum.SKIPPED,
                         errors=[
                             "Parent media object upload failed. Skipping attribute."
                         ],

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -1146,7 +1146,7 @@ class HARIUploader:
                     models.AnnotatableCreateResponse(
                         bulk_operation_annotatable_id="",
                         item_id=None,
-                        status=models.ResponseStatesEnum.SKIPPED,
+                        status=models.ResponseStatesEnum.MISSING_DATA,
                         errors=["Parent media upload failed. Skipping media object."],
                     )
                 )
@@ -1167,7 +1167,7 @@ class HARIUploader:
                     models.AttributeCreateResponse(
                         annotatable_id="",
                         item_id=None,
-                        status=models.ResponseStatesEnum.SKIPPED,
+                        status=models.ResponseStatesEnum.MISSING_DATA,
                         errors=[
                             "Parent media object upload failed. Skipping attribute."
                         ],

--- a/hari_client/upload/hari_uploader.py
+++ b/hari_client/upload/hari_uploader.py
@@ -1160,8 +1160,8 @@ class HARIUploader:
             skipped_attr_resp = models.BulkResponse()
             for attr in attributes:
                 skipped_attr_resp.results.append(
-                    models.AnnotatableCreateResponse(
-                        bulk_operation_annotatable_id="",
+                    models.AttributeCreateResponse(
+                        annotatable_id="",
                         item_id=None,
                         status=models.ResponseStatesEnum.BAD_DATA,
                         errors=[

--- a/tests/test_hari_uploader.py
+++ b/tests/test_hari_uploader.py
@@ -1782,7 +1782,27 @@ def test_hari_uploader_marks_dependencies_as_failed_when_media_object_upload_fai
                         bulk_operation_annotatable_id=media.bulk_operation_annotatable_id,
                     )
                 )
-        return models.BulkResponse(results=results, status=media_bulk_operation_status)
+        return models.BulkResponse(
+            results=results,
+            status=media_bulk_operation_status,
+            summary=models.BulkUploadSuccessSummary(
+                total=len(results),
+                successful=len(
+                    [
+                        x
+                        for x in results
+                        if x.status == models.ResponseStatesEnum.SUCCESS
+                    ]
+                ),
+                failed=len(
+                    [
+                        x
+                        for x in results
+                        if x.status != models.ResponseStatesEnum.SUCCESS
+                    ]
+                ),
+            ),
+        )
 
     client.create_medias = mock_create_medias
 
@@ -1825,7 +1845,25 @@ def test_hari_uploader_marks_dependencies_as_failed_when_media_object_upload_fai
                     )
                 )
         return models.BulkResponse(
-            results=results, status=media_object_bulk_operation_status
+            results=results,
+            status=media_object_bulk_operation_status,
+            summary=models.BulkUploadSuccessSummary(
+                total=len(results),
+                successful=len(
+                    [
+                        x
+                        for x in results
+                        if x.status == models.ResponseStatesEnum.SUCCESS
+                    ]
+                ),
+                failed=len(
+                    [
+                        x
+                        for x in results
+                        if x.status != models.ResponseStatesEnum.SUCCESS
+                    ]
+                ),
+            ),
         )
 
     client.create_media_objects = mock_create_media_objects


### PR DESCRIPTION
# Background
The upload summary and its statistics were generated from all the individual responses from the server.
That meant skipping some uploads of media_objects or attributes would reduce the number of total responses from the server because we did not even try to upload it.

[Aggregation of upload statistics](https://github.com/quality-match/hari-client/blob/75ac9c10524d2e2b4e288c7eff697bd22a5e99d8/hari_client/upload/hari_uploader.py#L1222-L1224)
[Uploader results](https://github.com/quality-match/hari-client/blob/75ac9c10524d2e2b4e288c7eff697bd22a5e99d8/hari_client/upload/hari_uploader.py#L677-L679)

[media objects are being excluded from upload](https://github.com/quality-match/hari-client/blob/75ac9c10524d2e2b4e288c7eff697bd22a5e99d8/hari_client/upload/hari_uploader.py#L1068-L1084)

## Changes
This patch creates dummy responses for all the skipped items

### Monday
https://quality-match.monday.com/boards/1606259534/pulses/1871935583