### PR TITLE
expose http_response_status_code in APIException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [major.minor.patch] - DD-MM-YYYY
 
+### New features
+
+- expose `http_response_status_code` in APIException
+
+## [major.minor.patch] - DD-MM-YYYY
+
 ### Breaking Changes
 
 - rename `MlAnnotationModel` to `MLAnnotationModel` [PR#118](https://github.com/quality-match/hari-client/pull/118)

--- a/hari_client/client/errors.py
+++ b/hari_client/client/errors.py
@@ -9,13 +9,13 @@ T = typing.TypeVar("T")
 
 class APIError(Exception):
     def __init__(self, response: requests.Response):
-        http_response_status_code = response.status_code
+        self.http_response_status_code = response.status_code
         self.message = ""
         try:
             self.message = response.json()
         except:
             pass
-        super().__init__(f"{http_response_status_code=}: {self.message=}")
+        super().__init__(f"{self.http_response_status_code=}: {self.message=}")
 
 
 class AuthenticationError(APIError):


### PR DESCRIPTION
Nice to have the response code accessible when catching the exception